### PR TITLE
fix(mlx): use native Hadamard transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,9 +110,12 @@ regime the 1.59× footprint buys, and where a Mac serving more than one user liv
 
 The M5 Pro results are a separate machine characterization, not a paired cross-chip A/B.
 Its B=1/8/16/128 entries are five-run medians from the 16-token, step-synchronized
-repeatability harness. M5 Pro P0 gates pass, while the complete suite is **165 passed,
-4 failed, 1 skipped** because of the documented fused-Hadamard comparison failures, so its
-results are not yet merge-qualified validation data. See [Known issues](#known-issues).
+repeatability harness. M5 Pro P0 gates pass, while the complete suite was **165 passed,
+4 failed, 1 skipped** at the benchmarked revision because its dense-matmul Hadamard
+test oracle selected MLX's TF32 path. That historical validation caveat is now resolved
+by comparing the fused butterfly with the production native butterfly; see
+[Resolved issues](#resolved-issues). The current complete suite is **170 passed,
+1 skipped** with default TF32; the performance numbers themselves have not been rerun.
 
 Full tables (ISL/OSL serving grid, prefill scaling, drift controls):
 [docs/PERFORMANCE.md](docs/PERFORMANCE.md). The complete bring-up and optimization
@@ -120,19 +123,19 @@ campaign — including every negative result, so you don't repeat them:
 [docs/BRINGUP_AND_PERF.md](docs/BRINGUP_AND_PERF.md). Raw result JSONs per machine:
 [`bench/results/`](bench/results/).
 
-## Known issues
+## Resolved issues
 
-- **M5 Pro, MLX 0.32.0, fused-Hadamard comparison:** with MLX's default TF32 path,
-  60.35–61.11% of fused fp16 outputs have a different bit pattern from the MLX
-  dense-matmul op chain, although the relative-error gate passes and the fused kernel
-  is bit-reproducible. Starting the process with `MLX_ENABLE_TF32=0` makes the complete
-  suite pass (169 passed, 1 skipped) and reduces the mismatch to 0.113–0.122%, but
-  does **not** make the two paths bit-exact; the test passes because its limit is 1%.
-  The fused output
-  was bit-exact with the independent NumPy reference in all four analysed shapes.
-  This is recorded as an unresolved backend-path comparison issue, not treated as a
-  gate fix. Per-shape counts and the paired throughput cost are in
-  [docs/PERFORMANCE.md](docs/PERFORMANCE.md#m5-pro-known-issue-fused-hadamard-versus-mlx-tf32).
+- **M5 Pro, MLX 0.32.0, fused-Hadamard comparison:** the old test compared an
+  explicit FP32 butterfly with a dense matmul that selected MLX's TF32/NAX path.
+  It therefore measured two reduction algorithms and precisions, not the production
+  fused/native equivalence. `moe.had_blocks` now uses `mx.hadamard_transform`, and
+  the fused test requires its final FP16 output to be bit exact with that native
+  butterfly under the default TF32 setting. The independent NumPy/reference check
+  remains as a tolerance test. Global `MLX_ENABLE_TF32=0` is no longer needed for
+  this gate; the complete suite now reports **170 passed, 1 skipped** both with
+  default TF32 and with `MLX_ENABLE_TF32=0`. Historical counts and the diagnostic
+  TF32 A/B are retained in
+  [docs/PERFORMANCE.md](docs/PERFORMANCE.md#m5-pro-resolved-issue-dense-matmul-test-oracle-and-tf32).
 
 ## Repository layout
 

--- a/docs/BRINGUP_AND_PERF.md
+++ b/docs/BRINGUP_AND_PERF.md
@@ -1295,6 +1295,13 @@ exactly.
 
 Correctness battery green (Paris / 391 / coherent thinking-mode haiku).
 
+> **Current status:** this subsection records the original dense-matmul op chain.
+> Production `moe.had_blocks` now uses `mx.hadamard_transform`, whose radix-2
+> butterfly order matches the fused kernel. The current gate requires their final
+> FP16 outputs to be bit exact under both default TF32 and `MLX_ENABLE_TF32=0`;
+> the dense-matmul/TF32 mismatch is retained only as historical diagnosis in
+> [PERFORMANCE.md](PERFORMANCE.md#m5-pro-resolved-issue-dense-matmul-test-oracle-and-tf32).
+
 ### 17.3 Why it was worth only 7–11% and not the 20% projected
 
 The ablation said the transform pipeline was ~20% of both prefill and decode, and

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -186,21 +186,25 @@ microbench varied across three consecutive runs: K2 24–49 GB/s and K3 33–54 
 The value gates passed every time; these short microbench figures are retained as a
 stability observation and are not used for the throughput headlines below.
 
-The complete suite is nevertheless **165 passed, 4 failed, 1 skipped**. All four
-failures are `tests/test_fused_had.py::test_fused_matches_op_chain`: the primary
+At the benchmarked runtime revision, the complete suite was **165 passed, 4 failed,
+1 skipped**. All four failures were the former
+`tests/test_fused_had.py::test_fused_matches_op_chain`: the primary
 `2e-3` relative-error bound passes, but 60.35–61.11% of fp16 bit patterns differ
 from the dense-matmul op chain on this M5 Pro, exceeding the test's 1% secondary
 bound. The fused path remains bit-reproducible and its independent NumPy-reference
 test passes. No gate was excluded or loosened, so this is machine-characterization
-data rather than a merge-green validation result.
+data rather than a merge-green validation result. This was subsequently resolved
+by replacing the dense-matmul test oracle and production op chain with MLX's native
+butterfly; the performance tables below still describe the recorded revision and
+have not been rerun.
 
-#### M5 Pro known issue: fused Hadamard versus MLX TF32
+#### M5 Pro resolved issue: dense-matmul test oracle and TF32
 
-On this M5 Pro, MLX 0.32.0 selects its NAX/TF32 path for the FP32 dense matmul in
-the comparison op chain when `MLX_ENABLE_TF32` is unset. The fused Metal kernel
-continues to perform an explicit FP32 butterfly. The two paths therefore combine
-different operation order with different FP32 matmul precision, making the raw
-fp16 comparison fail widely even though the maximum-error gate remains green.
+On this M5 Pro, MLX 0.32.0 selected its NAX/TF32 path for the FP32 dense matmul in
+the old comparison op chain when `MLX_ENABLE_TF32` was unset. The fused Metal kernel
+performed an explicit FP32 butterfly. The test therefore combined different
+operation order with different FP32 matmul precision, making the raw fp16 comparison
+fail widely even though the maximum-error gate remained green.
 
 The four test shapes were measured again in fresh processes with TF32 at its
 default and with `MLX_ENABLE_TF32=0`. Counts compare the raw fp16 bit patterns;
@@ -213,13 +217,20 @@ the test requires the op-chain mismatch rate to be below 1%.
 | 300 × 1024 | 187,741 / 307,200 (61.1136%) | 369 / 307,200 (0.1201%) | 0 / 307,200 |
 | 2048 × 2048 | 2,557,851 / 4,194,304 (60.9839%) | 4,933 / 4,194,304 (0.1176%) | 0 / 4,194,304 |
 
-`MLX_ENABLE_TF32=0 .venv/bin/python -m pytest tests/ -v` reports **169 passed,
-1 skipped**; the targeted `tests/test_fused_had.py` subset is **8 passed**. This
-is not a bit-exact resolution: 0.113–0.122% of the
-fused/op-chain outputs still differ, and the current test passes only because
-that tail is below 1%. Repeated fused evaluations remain bit-identical. Runtime
-users who require the previous op chain can instead set `ESCHA_MLX_FUSED_HAD=0`;
-no correctness gate was loosened or skipped.
+In that historical implementation,
+`MLX_ENABLE_TF32=0 .venv/bin/python -m pytest tests/ -v` reported **169 passed,
+1 skipped** and the targeted subset reported **8 passed**. This was not a bit-exact
+resolution: 0.113–0.122% of fused/dense-matmul outputs still differed, and the test
+passed only because that tail was below 1%.
+
+The current implementation instead uses `mx.hadamard_transform` for the native
+op chain. Both paths now execute the same radix-2 butterfly order, and the fused
+test requires zero differing FP16 bits across the four shapes above with TF32 left
+at its default. `ESCHA_MLX_FUSED_HAD=0` selects this native chain. The independent
+NumPy comparison remains tolerance-based because its matrix multiplication has a
+different reduction order. The complete current suite reports **170 passed,
+1 skipped** both under default TF32 and with `MLX_ENABLE_TF32=0`. No correctness
+gate is loosened or skipped.
 
 Turning off TF32 also has a measurable cost. A same-session default/off/default
 A/B/A used `bench.baseline` phases B and C at runtime revision `aec1ea8` and model
@@ -240,8 +251,9 @@ revision `32016b7`, so this is not a weight change.
 Peak memory was unchanged at every corresponding point. The first ISL-128 arm
 was cold and the batched-prefill closing arm drifted substantially, so neither is
 used for a performance claim. The stable observations are a roughly 19–20%
-long-prompt prefill loss and a 1–4% decode loss; disabling TF32 is therefore a
-diagnostic/workaround, not the default-performance recommendation. Raw A/B/A JSON:
+long-prompt prefill loss and a 1–4% decode loss; disabling TF32 was therefore a
+useful diagnosis of the former dense-matmul oracle, not a current workaround or
+default-performance recommendation. Raw A/B/A JSON:
 [tf32_aba.json](../bench/results/m5-pro-24gb/tf32_aba.json).
 
 ### In-process ABCD baseline
@@ -382,12 +394,13 @@ precision, and each leaves decode bit-reproducible.
    run rather than accumulating. For calibration, changing batch size from 1 to
    16 perturbs logits *more* than this does. `ESCHA_MLX_GDN_STATE=fp32` restores
    the f32 behaviour at ~10% throughput cost above batch 32.
-3. **Fused expert input transform.** The Hadamard is computed by an in-register
-   butterfly rather than a dense 128×128 matmul — the same f32 arithmetic in a
-   different summation order, which avoids materialising ~150 MB of f32
-   intermediates per layer. Within 2e-3 relative of both the op chain and the
-   NumPy reference; 0.12% of f16 outputs differ by one ulp.
-   `ESCHA_MLX_FUSED_HAD=0` restores the op chain exactly.
+3. **Fused expert input transform.** Both the fused kernel and the native op chain
+   use a radix-2 butterfly instead of a dense 128×128 matmul. The fused kernel also
+   combines the gather, input scale, transform, output scale and cast, avoiding
+   ~150 MB of f32 intermediate traffic per layer. Its final f16 output is bit exact
+   with `mx.hadamard_transform`; both remain within the reference tolerance against
+   the independent NumPy implementation. `ESCHA_MLX_FUSED_HAD=0` selects the native
+   op chain.
 
 ## Reproducing
 

--- a/escha_mlx/moe.py
+++ b/escha_mlx/moe.py
@@ -16,28 +16,14 @@ from . import msl, ref
 RS = ref.RS
 
 
-def _h128_matrix() -> mx.array:
-    i = np.arange(128, dtype=np.uint32)
-    par = np.bitwise_count(i[:, None] & i[None, :]).astype(np.int64)
-    h = np.where(par % 2 == 0, 1.0, -1.0).astype(np.float32)
-    return mx.array(h)
-
-
-_H128: mx.array | None = None
-
-
 def had_blocks(x: mx.array) -> mx.array:
-    """Unnormalized 128-point WHT (Sylvester order) on 128-blocks of last dim.
-
-    Matmul-by-H formulation: order-exact vs ref.h128 on every backend
-    (mx.hadamard_transform is the P4 fast path, gated by G0.1).
-    """
-    global _H128
-    if _H128 is None:
-        _H128 = _h128_matrix()
+    """MLX-native unnormalized 128-point WHT on last-dimension blocks."""
     shape = x.shape
-    c = shape[-1]
-    y = x.reshape(-1, c // 128, 128) @ _H128
+    if shape[-1] % 128:
+        raise ValueError(
+            f"Hadamard dimension must be divisible by 128, got {shape[-1]}"
+        )
+    y = mx.hadamard_transform(x.reshape(-1, 128), scale=1.0)
     return y.reshape(shape)
 
 

--- a/escha_mlx/msl.py
+++ b/escha_mlx/msl.py
@@ -498,7 +498,7 @@ def _scaled_had_source(rs: float) -> str:
 
     The unfused chain is arithmetically trivial and memory-brutal: at m=2048,
     IC=2048 it materialises `[m, IC]` f32 for the cast, again for the rin gather,
-    again for the product, again for the matmul output, again for the RS scale --
+    again for the product, again for the native transform output, again for the RS scale --
     ~150 MB of traffic per layer per leg to do 128 adds per output.  Measured
     cost: 15.8% of prefill and 11.3% of decode for the rin stage alone, plus
     3.3%/8.9% for the Hadamard (doc §16.2).
@@ -508,10 +508,10 @@ def _scaled_had_source(rs: float) -> str:
     the input and the output ever reach DRAM.
 
     The transform is the in-place radix-2 butterfly, 7 stages, which computes
-    y[j] = sum_i (-1)^popcount(i&j) x[i] -- the same Sylvester-ordered
-    unnormalised WHT the matmul-by-H computes, in a different summation order.
-    Not bit-identical to the matmul (no reduction order is), and gated to the
-    same tolerance the matmul itself is held to against ref.h128.
+    y[j] = sum_i (-1)^popcount(i&j) x[i] -- the same Sylvester-ordered,
+    unnormalised WHT and reduction order as mx.hadamard_transform. The final f16
+    output is gated bit-for-bit against that native op chain; a separate
+    tolerance test ties both implementations to ref.h128.
     """
     return f"""
     uint tid = thread_position_in_threadgroup.x;

--- a/tests/test_fused_had.py
+++ b/tests/test_fused_had.py
@@ -4,11 +4,9 @@ Replaces ~5 MLX ops, each materialising an [m, IC] f32 tensor, with one kernel
 that keeps everything in threadgroup memory. Measured 15.8% of prefill and 11.3%
 of decode was the rin stage alone (doc §16.2).
 
-It is NOT bit-identical to the op chain: the butterfly sums 128 terms in a
-different order than the matmul-by-H. It IS the same f32 arithmetic — no
-precision is dropped — and it is held to the same tolerance the matmul itself is
-held to against ref.h128, plus reproducibility, which is the property this
-runtime actually guarantees.
+The fused and native op-chain paths use the same radix-2 butterfly order. The
+fused path must therefore be bit-identical at its final f16 output; the separate
+NumPy test keeps the butterfly's mathematical result tied to ref.h128.
 """
 from __future__ import annotations
 
@@ -32,7 +30,7 @@ def _case(m, IC, E, seed):
 
 @pytest.mark.parametrize("m,IC,E", [(8, 512, 256), (96, 2048, 64),
                                     (300, 1024, 128), (2048, 2048, 256)])
-def test_fused_matches_op_chain(m, IC, E):
+def test_fused_matches_native_chain_bit_exact(m, IC, E):
     import mlx.core as mx
     from escha_mlx import moe, msl, ref
 
@@ -45,14 +43,14 @@ def test_fused_matches_op_chain(m, IC, E):
     b = np.array(want).astype(np.float32)
     scale = max(np.abs(b).max(), 1e-6)
     assert np.abs(a - b).max() <= 2e-3 * scale, np.abs(a - b).max() / scale
-    # and the f16 outputs should agree almost everywhere
+    # The fused kernel and MLX native transform use the same butterfly order.
     nd = int((np.array(got).view(np.uint16) != np.array(want).view(np.uint16)).sum())
-    assert nd / a.size < 0.01, f"{100*nd/a.size:.2f}% of f16 elements differ"
+    assert nd == 0, f"{nd}/{a.size} f16 elements differ"
 
 
 @pytest.mark.parametrize("m,IC,E", [(96, 2048, 64), (300, 1024, 128)])
 def test_fused_is_bit_reproducible(m, IC, E):
-    """Determinism is the guarantee; reassociation is allowed, drift is not."""
+    """Repeated fused evaluations must produce identical output bits."""
     import mlx.core as mx
     from escha_mlx import msl, ref
 

--- a/tests/test_metal.py
+++ b/tests/test_metal.py
@@ -106,19 +106,11 @@ def test_decode_hash_equals_lut(monkeypatch):
         "hash decode != LUT on this GPU/compiler — set ESCHA_MLX_LUT=1 and report"
 
 
-def test_mx_hadamard_transform_order():
-    """Informational (P4 fast path): does mx.hadamard_transform match Sylvester
-    order? The production path is the matmul in moe.had_blocks either way —
-    a mismatch here is a note for the perf campaign, NOT a failure."""
+def test_native_hadamard_transform_order():
+    """The production native transform must preserve the reference ordering."""
     import mlx.core as mx
     from escha_mlx import ref
     x = np.random.default_rng(1).standard_normal((2, 128)).astype(np.float32)
     want = ref.h128(x)
-    try:
-        got = np.array(mx.hadamard_transform(mx.array(x), scale=1.0))
-    except Exception as e:  # pragma: no cover
-        print(f"mx.hadamard_transform unavailable: {e!r}")
-        return
-    ok = np.abs(got - want).max() < 1e-3 * np.abs(want).max()
-    print(f"mx.hadamard_transform Sylvester-order match: {ok} "
-          f"({'fast path usable in P4' if ok else 'keep matmul path'})")
+    got = np.array(mx.hadamard_transform(mx.array(x), scale=1.0))
+    assert np.abs(got - want).max() < 1e-3 * np.abs(want).max()

--- a/tests/test_mlx_cpu.py
+++ b/tests/test_mlx_cpu.py
@@ -75,6 +75,18 @@ def test_had_blocks_matches_ref():
     assert np.abs(got - want).max() < 1e-3 * np.abs(want).max()
 
 
+def test_had_blocks_matches_native_bit_exact():
+    import mlx.core as mx
+    from escha_mlx import moe
+    rng = np.random.default_rng(19)
+    x = mx.array(rng.standard_normal((3, 256)).astype(np.float32))
+    got = np.array(moe.had_blocks(x))
+    want = np.array(mx.hadamard_transform(x.reshape(-1, 128), scale=1.0))
+    assert np.array_equal(
+        got.reshape(-1, 128).view(np.uint32), want.view(np.uint32)
+    )
+
+
 def _synth_experts(rng, E, ic, oc, K):
     from escha_mlx import moe
     code = rng.integers(-32768, 32768, size=(E, ic // 16, oc // 16, 16 * K), dtype=np.int16)


### PR DESCRIPTION
## What

<!-- One change per PR. What does it do, and why? -->

## Numerics

- [x] Bit-identical: `pytest tests/ -v` green, kernel gates included (paste the Metal gate summary if you touched a kernel)
- [x] OR deliberate numerics change: behind an env flag, previous behavior recoverable, documented in the README tuning table, validated end-to-end

## Performance (if claimed)

<!-- Paired same-session A/B, baseline re-run as drift control. -->

- Machine: <!-- chip (base/Pro/Max/Ultra), RAM, macOS, mlx version -->
- Numbers: <!-- before / after / drift control; harness used (bench/...) -->

## Checklist

- [x] `pytest tests/ -v` passes locally
- [x] Docs updated where behavior or defaults changed
- [x] Commits signed off (`git commit -s`)
