### PR TITLE
refactor: centralize environment variable management

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,20 @@ Tests self-skip by capability (`needs_mlx` / `needs_metal` / `needs_ckpt` marker
 checkpoint the end-to-end tests skip. Everything else runs from the small goldens
 committed in `tests/data/`.
 
+## Configuration and environment variables
+
+Environment variables are escape hatches, not a substitute for an explicit
+runtime API. Stable user-facing settings should be normal typed arguments when
+an API exists; environment variables are appropriate for deployment policy,
+low-level kernel selection, emergency fallback, and development inputs.
+
+Every `ESCHA_*` variable must be declared in `escha_mlx/envs.py`, assigned to
+one ownership layer, parsed and validated there, and documented in
+`docs/INSTALL.md`. Package code must use the declaration rather than reading
+`os.environ` directly. Add or update `tests/test_envs.py` with every new variable.
+Build/toolchain variables belong to the build layer; they must not change normal
+serving behavior after installation.
+
 ## The correctness bar
 
 1. **Kernel and numerics changes must stay bit-identical** to the goldens and to the

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -199,32 +199,54 @@ sequence, and bound context at the request level.
 
 ## Tuning reference
 
-All optional. The defaults are what we measured as best on an M4; every one of
-these is gated bit-identical or documented where it is not.
+All environment variables are declared, parsed, and validated in
+`escha_mlx/envs.py`. They are separated by ownership rather than precedence:
 
-| variable | effect |
-|---|---|
-| `ESCHA_MLX_WIRED_GB=N` | wire N GB. **Required above a ~18 GB working set** (see the cliff above). Must be ≤ the cap. |
-| `ESCHA_MLX_FUSED_HAD=0` | use native MLX op chains for the expert input and output transforms. The default fused Metal kernels combine the scale gathers, radix-2 Hadamard, scaling and f16 cast without changing the final f16 bits; set this to 0 for performance comparison or debugging. |
-| `ESCHA_MLX_GDN_STATE=fp32` | store the recurrent state in f32 instead of fp16. Costs ~10% throughput at batch ≥32; the per-sequence cost is architecture-dependent — 31.5 MB on the 35B MoE (30 GDN layers × 32 v-heads), 75.5 MB on the 27B dense (48 × 48). The loader logs the actual figure for your model. Use it if you need the pre-fp16 numerics exactly. |
-| `ESCHA_MLX_LAST_LOGIT=0` | compute logits for **all** prompt positions, not just the last. Needed for per-position scoring (loglikelihood eval); costs ~7% prefill. |
-| `ESCHA_MLX_Q8_GROUP=64` | 64-wide Q8 groups instead of 128. Identical numerics, +140 MB. |
-| `ESCHA_MLX_BLOCK_R=N` | pin rows-per-expert-group. Default is size-dependent. |
-| `ESCHA_MLX_KT_BLOCK=N` | code tiles staged per barrier pair. Default 4. |
-| `ESCHA_MLX_GEMV=staged` | revert to the barrier/threadgroup-staged per-row GEMV (default is the barrier-free direct kernel). Bit-identical. |
-| `ESCHA_MLX_DENSE=fp16` | fp16 weights for the **non-expert** tensors (embed/head) instead of the Q8 repack. +~1.9 GB resident; bit-identical weight values. Unrelated to the `ESCHA_MLX_DENSE_*` dense-architecture flags below. |
-| `ESCHA_MLX_LUT=1` | table-based codec decode instead of the multiply-hash. Bit-exact by construction; use if a future Metal compiler ever breaks fp16 round-to-nearest-even in the hash path. |
-| `ESCHA_MLX_MOE=ops` | NumPy expert path. Very slow; a correctness oracle, not for serving. |
-| `ESCHA_MLX_BIAS=1` | apply the per-linear correction a dense export ships. **Off by default, and this is a real fork in the model, not a tuning knob** — see the section above. |
-| `ESCHA_MLX_LINEAR=ops` | NumPy path for the coded linears of a **dense** model (the MoE flag's counterpart). Very slow, and it materializes each decoded weight in **f32** and caches it for the module's lifetime — about 97 GB if you touch every linear of the 27B. A correctness oracle for a truncated load or a single layer, not a whole-model fallback. |
-| `ESCHA_MLX_DENSE_BLOCK_R=N` | pin rows-per-group for the dense row-blocked GEMM (1 = always the per-row kernel). Default is size-dependent, now measured — see below. Bit-identical at every R. |
-| `ESCHA_MLX_DENSE_MAT=1` | run the dense prefill GEMM on the simdgroup matrix units. **Not bit-identical to the goldens** — deterministic, but the sum is reassociated; split-K is the only other such path. See below. |
+- **deployment** controls process/device resource policy;
+- **runtime** controls stable, user-visible behavior or numerics;
+- **kernel** selects low-level implementations and performance strategies;
+- **development** supplies inputs used only by tests and benchmarks;
+- **build** is reserved for future native-extension/toolchain settings and is
+  currently empty.
 
-Five further flags (`ESCHA_MLX_SPLITK`, `ESCHA_MLX_FETCH`, `ESCHA_MLX_SORTX`,
-`ESCHA_MLX_PREFETCH`, `ESCHA_MLX_GEMV_PF`) select alternate kernel strategies
-that measured neutral or worse on a 10-core M4. They are kept because the
-trade-offs are hardware-dependent and may favour wider GPUs (M-series
-Max/Ultra). All are gated bit-identical.
+Environment variables are process-level overrides and are read only where they
+are explicitly used; they do not implicitly override CLI arguments. The defaults
+below are what we measured as best on an M4. Every alternate kernel path is gated
+bit-identical or documents where it is not.
+
+| layer | variable | effect |
+|---|---|---|
+| deployment | `ESCHA_MLX_WIRED_GB=N` | Wire N GB. **Required above a ~18 GB working set** (see the cliff above). Must be ≤ the cap. |
+| runtime | `ESCHA_MLX_GDN_STATE=fp32` | Store the recurrent state in f32 instead of fp16. Costs ~10% throughput at batch ≥32; the per-sequence cost is architecture-dependent — 31.5 MB on the 35B MoE and 75.5 MB on the 27B dense. The loader logs the actual figure. |
+| runtime | `ESCHA_MLX_LAST_LOGIT=0` | Compute logits for **all** prompt positions, not just the last. Needed for per-position scoring (loglikelihood eval); costs ~7% prefill. |
+| runtime | `ESCHA_MLX_Q8_GROUP=64` | Use 64-wide Q8 groups instead of 128. Identical numerics, +140 MB. |
+| runtime | `ESCHA_MLX_BIAS=1` | Apply the per-linear correction a dense export ships. **Off by default, and this is a real fork in the model, not a tuning knob** — see the section above. |
+| kernel | `ESCHA_MLX_FUSED_HAD=0` | Use native MLX op chains for the expert transforms. The default fused kernels are bit-identical; set this to 0 for comparison or debugging. |
+| kernel | `ESCHA_MLX_GEMV=staged` | Revert to the barrier/threadgroup-staged per-row GEMV. Bit-identical. |
+| kernel | `ESCHA_MLX_FETCH=shuffle` | Shuffle-broadcast code tiles instead of direct loads. Measured slower on a 10-core M4. |
+| kernel | `ESCHA_MLX_SPLITK=auto` | Enable the size-based split-K policy, or set a positive integer to pin the factor. Measured slower on a 10-core M4. |
+| kernel | `ESCHA_MLX_BLOCK_R=N` | Pin rows per expert group. Unset uses the size-dependent policy. |
+| kernel | `ESCHA_MLX_KT_BLOCK=N` | Stage 1, 2, 4, 8, 16, or 32 code tiles per barrier pair. Default 4. |
+| kernel | `ESCHA_MLX_SORTX=1` | Pre-sort inputs into expert order. Measured neutral or slower on a 10-core M4. |
+| kernel | `ESCHA_MLX_PREFETCH=1` | Prefetch code tiles into registers. Measured neutral or slower on a 10-core M4. |
+| kernel | `ESCHA_MLX_DENSE=fp16` | Use fp16 dense weights instead of the Q8 repack. +~1.9 GB resident; bit-identical weight values. |
+| kernel | `ESCHA_MLX_LUT=1` | Use table-based codec decode instead of multiply-hash. Bit-exact fallback for future Metal compiler changes. |
+| kernel | `ESCHA_MLX_MOE=ops` | Use the NumPy expert path. Very slow; a correctness oracle, not for serving. |
+| kernel | `ESCHA_MLX_LINEAR=ops` | Use the NumPy path for coded linears of a **dense** model. Very slow, and materializes decoded weights in f32; use only as a correctness oracle for a truncated load or single layer. |
+| kernel | `ESCHA_MLX_GEMV_PF=N` | Prefetch N code tiles in the direct GEMV. Default 1; alternate depths measured neutral or slower on a 10-core M4. |
+| kernel | `ESCHA_MLX_DENSE_BLOCK_R=N` | Pin rows per group for dense row-blocked GEMM (1 = per-row kernel). Unset uses the measured size policy; bit-identical at every R. |
+| kernel | `ESCHA_MLX_DENSE_MAT=1` | Run dense prefill GEMM on simdgroup matrix units. **Not bit-identical to the goldens** — deterministic, but the sum is reassociated. See below. |
+
+The development-only variables `ESCHA_MODEL=/path/to/checkpoint` and
+`ESCHA_DENSE_MODEL=/path/to/dense-checkpoint` select checkpoints for tests and
+the commands in `RUNBOOK.md`; model loading itself continues to take an explicit
+path. `ESCHA_MLX_SLOW_TESTS=1` opts in to memory-heavy checkpoint tests.
+
+Five alternate strategy flags (`ESCHA_MLX_SPLITK`, `ESCHA_MLX_FETCH`,
+`ESCHA_MLX_SORTX`, `ESCHA_MLX_PREFETCH`, `ESCHA_MLX_GEMV_PF`) measured neutral
+or worse on a 10-core M4. They remain available because the trade-offs are
+hardware-dependent and may favour wider GPUs (M-series Max/Ultra). All are
+gated bit-identical.
 
 **`ESCHA_MLX_DENSE_BLOCK_R` has now been measured.** The dense path was
 developed on Linux, where the Metal kernels do not run, so the policy
@@ -246,20 +268,14 @@ to the per-row kernel. Re-sweep with
 `bench/prefill_profile.py --sweep-r 4,8,16,32`.
 
 **`ESCHA_MLX_DENSE_MAT` is not bit-identical to the goldens** — split-K is the
-only other path here that is not — and
-it is off by default for that reason alone — not because it is inaccurate. It
-computes the same products (on this hardware the matrix units multiply two
-halves into an f32 accumulator *exactly*: a half×half product needs 22 mantissa
-bits and f32 carries 24) but sums them in a different order, so it is
-deterministic and reproducible while differing from the scalar kernel in the
-last bits. Measured on the 27B dense model: **+16–17% prefill** (38.9 → 45.5
-tok/s at ISL 512), decode unchanged — at batch 1 there is one row, the size
-policy returns `R = 1`, and this kernel is never reached. Logit-level effect on
-the shipped checkpoint: mean deviation 0.46% of the logits' own sigma, greedy
-token and top-5 unchanged, deep-tail ordering not preserved. On a near tie it
-*can* reorder the top two, which is what "tolerance-gated rather than
-bit-identical" means in practice. A/B it with
-`bench/prefill_profile.py --sweep-dense-mat`.
+only other path here that is not — and it is off by default for that reason
+alone, not because it is inaccurate. It computes the same products but sums
+them in a different order, so it is deterministic and reproducible while
+differing from the scalar kernel in the last bits. Measured on the 27B dense
+model: **+16–17% prefill** (38.9 → 45.5 tok/s at ISL 512), decode unchanged.
+Logit-level effect on the shipped checkpoint: mean deviation 0.46% of the
+logits' own sigma, greedy token and top-5 unchanged, deep-tail ordering not
+preserved. A/B it with `bench/prefill_profile.py --sweep-dense-mat`.
 
 ## Troubleshooting
 

--- a/escha_mlx/dense.py
+++ b/escha_mlx/dense.py
@@ -50,13 +50,12 @@ Paths:
 from __future__ import annotations
 
 import logging
-import os
 
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 
-from . import msl, ref
+from . import envs, msl, ref
 from .moe import had_blocks   # the shared 128-block WHT, not expert-specific
 
 logger = logging.getLogger(__name__)
@@ -129,7 +128,7 @@ def apply_bias() -> bool:
     (`y = (x * s_in) @ W * s_out + bias`) asks for -- run it as a paired A/B on
     a real task before treating either as correct.
     """
-    return os.environ.get("ESCHA_MLX_BIAS", "0") == "1"
+    return bool(envs.ESCHA_MLX_BIAS.get())
 
 
 def linear_mode() -> str:
@@ -138,11 +137,8 @@ def linear_mode() -> str:
     Distinct from ESCHA_MLX_DENSE, which selects how the *int8* dense tensors
     (embed/head) are repacked — see escha_mlx.quant.
     """
-    mode = os.environ.get("ESCHA_MLX_LINEAR",
-                          "fused" if mx.metal.is_available() else "ops")
-    if mode not in ("fused", "ops"):
-        raise ValueError(f"ESCHA_MLX_LINEAR must be 'fused' or 'ops', got {mode!r}")
-    return mode
+    return envs.ESCHA_MLX_LINEAR.get(
+        default="fused" if mx.metal.is_available() else "ops")
 
 
 def pack_code(code_i16: np.ndarray) -> mx.array:

--- a/escha_mlx/envs.py
+++ b/escha_mlx/envs.py
@@ -1,0 +1,393 @@
+"""Central registry for escha-mlx environment variables.
+
+Environment variables are process-level overrides, not the primary model API.
+They are grouped by ownership so low-level kernel experiments do not get mixed
+with stable runtime behavior or deployment policy:
+
+* ``BUILD``       -- native extension/toolchain settings (none today).
+* ``DEPLOYMENT``  -- machine and process resource policy.
+* ``RUNTIME``     -- stable behavior with user-visible semantic impact.
+* ``KERNEL``      -- implementation selection, fallback, and performance tuning.
+* ``DEVELOPMENT`` -- test and benchmark inputs.
+
+Values are deliberately read on every ``get()``.  Benchmark harnesses and a few
+tests switch kernel strategies inside one process, and caching here would make
+their results depend on import order.  Call sites that need a fixed setting
+(for example a model's MoE backend) read once when constructing that object.
+"""
+from __future__ import annotations
+
+import math
+import os
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Callable, Generic, Iterable, TypeVar, cast
+
+T = TypeVar("T")
+
+DEFAULT_Q8_GROUP = 128
+
+
+class EnvLayer(str, Enum):
+    """Ownership layer for an environment variable."""
+
+    BUILD = "build"
+    DEPLOYMENT = "deployment"
+    RUNTIME = "runtime"
+    KERNEL = "kernel"
+    DEVELOPMENT = "development"
+
+
+class _Unset:
+    pass
+
+
+UNSET = _Unset()
+
+
+@dataclass(frozen=True)
+class EnvVar(Generic[T]):
+    """Typed, dynamically-read environment variable declaration."""
+
+    name: str
+    layer: EnvLayer
+    parser: Callable[[str], T]
+    description: str
+    default: T | _Unset = UNSET
+    value_help: str = "a valid value"
+
+    def is_set(self) -> bool:
+        return self.name in os.environ
+
+    def get(self, *, default: T | _Unset = UNSET) -> T | None:
+        """Return the parsed value, an explicit/default value, or ``None``.
+
+        ``default=`` is useful when the default depends on runtime capability,
+        such as selecting the Metal MoE backend only when Metal is available.
+        """
+        raw = os.environ.get(self.name)
+        if raw is None:
+            value = self.default if isinstance(default, _Unset) else default
+            return None if isinstance(value, _Unset) else cast(T, value)
+        try:
+            return self.parser(raw)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{self.name} must be {self.value_help}, got {raw!r}"
+            ) from exc
+
+
+def _string(value: str) -> str:
+    return value
+
+
+def _bool(value: str) -> bool:
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError("invalid boolean")
+
+
+def _choice(*choices: str) -> Callable[[str], str]:
+    allowed = frozenset(choices)
+
+    def parse(value: str) -> str:
+        normalized = value.strip().lower()
+        if normalized not in allowed:
+            raise ValueError("invalid choice")
+        return normalized
+
+    return parse
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise ValueError("not positive")
+    return parsed
+
+
+def _kt_block(value: str) -> int:
+    parsed = _positive_int(value)
+    if parsed not in {1, 2, 4, 8, 16, 32}:
+        raise ValueError("unsupported tile count")
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed) or parsed <= 0:
+        raise ValueError("not positive")
+    return parsed
+
+
+def _split_k(value: str) -> str | int:
+    normalized = value.strip().lower()
+    return "auto" if normalized == "auto" else _positive_int(normalized)
+
+
+# Deployment policy ---------------------------------------------------------
+
+ESCHA_MLX_WIRED_GB = EnvVar(
+    "ESCHA_MLX_WIRED_GB",
+    EnvLayer.DEPLOYMENT,
+    _positive_float,
+    "Unified-memory amount to wire through MLX, in decimal GB.",
+    value_help="a positive number of GB",
+)
+
+
+# Stable runtime behavior ---------------------------------------------------
+
+ESCHA_MLX_GDN_STATE = EnvVar(
+    "ESCHA_MLX_GDN_STATE",
+    EnvLayer.RUNTIME,
+    _choice(
+        "fp16", "float16", "f16",
+        "bf16", "bfloat16",
+        "fp32", "float32", "f32",
+    ),
+    "Storage dtype for the recurrent GDN state.",
+    default="fp16",
+    value_help=(
+        "one of f16, fp16, float16, bf16, bfloat16, f32, fp32, or float32"
+    ),
+)
+
+ESCHA_MLX_LAST_LOGIT = EnvVar(
+    "ESCHA_MLX_LAST_LOGIT",
+    EnvLayer.RUNTIME,
+    _bool,
+    "Compute only the final prompt position's logits during prefill.",
+    default=True,
+    value_help="a boolean (0/1, false/true, no/yes, or off/on)",
+)
+
+ESCHA_MLX_Q8_GROUP = EnvVar(
+    "ESCHA_MLX_Q8_GROUP",
+    EnvLayer.RUNTIME,
+    _positive_int,
+    "Requested MLX affine-Q8 group size.",
+    default=DEFAULT_Q8_GROUP,
+    value_help="a positive integer",
+)
+
+ESCHA_MLX_BIAS = EnvVar(
+    "ESCHA_MLX_BIAS",
+    EnvLayer.RUNTIME,
+    _bool,
+    "Apply the per-linear correction shipped by dense exports.",
+    default=False,
+    value_help="a boolean (0/1, false/true, no/yes, or off/on)",
+)
+
+
+# Kernel implementation and fallback selection -----------------------------
+
+ESCHA_MLX_DENSE = EnvVar(
+    "ESCHA_MLX_DENSE",
+    EnvLayer.KERNEL,
+    _choice("q8", "fp16"),
+    "Dense-weight implementation used while loading a checkpoint.",
+    default="q8",
+    value_help="one of q8 or fp16",
+)
+
+ESCHA_MLX_MOE = EnvVar(
+    "ESCHA_MLX_MOE",
+    EnvLayer.KERNEL,
+    _choice("fused", "ops"),
+    "MoE implementation; the unset default depends on Metal availability.",
+    value_help="one of fused or ops",
+)
+
+ESCHA_MLX_FUSED_HAD = EnvVar(
+    "ESCHA_MLX_FUSED_HAD",
+    EnvLayer.KERNEL,
+    _bool,
+    "Use fused expert input/output Hadamard kernels.",
+    default=True,
+    value_help="a boolean (0/1, false/true, no/yes, or off/on)",
+)
+
+ESCHA_MLX_LUT = EnvVar(
+    "ESCHA_MLX_LUT",
+    EnvLayer.KERNEL,
+    _bool,
+    "Use the codec lookup-table fallback instead of multiply-hash decode.",
+    default=False,
+    value_help="a boolean (0/1, false/true, no/yes, or off/on)",
+)
+
+ESCHA_MLX_GEMV = EnvVar(
+    "ESCHA_MLX_GEMV",
+    EnvLayer.KERNEL,
+    _choice("direct", "staged"),
+    "Per-row GEMV implementation.",
+    default="direct",
+    value_help="one of direct or staged",
+)
+
+ESCHA_MLX_FETCH = EnvVar(
+    "ESCHA_MLX_FETCH",
+    EnvLayer.KERNEL,
+    _choice("load", "shuffle"),
+    "Code-tile fetch implementation for direct GEMV.",
+    default="load",
+    value_help="one of load or shuffle",
+)
+
+ESCHA_MLX_SPLITK = EnvVar(
+    "ESCHA_MLX_SPLITK",
+    EnvLayer.KERNEL,
+    _split_k,
+    "Split-K factor, or auto for the size-based policy.",
+    default=1,
+    value_help="a positive integer or auto",
+)
+
+ESCHA_MLX_BLOCK_R = EnvVar(
+    "ESCHA_MLX_BLOCK_R",
+    EnvLayer.KERNEL,
+    _positive_int,
+    "Rows per expert group; unset uses the size-based policy.",
+    value_help="a positive integer",
+)
+
+ESCHA_MLX_KT_BLOCK = EnvVar(
+    "ESCHA_MLX_KT_BLOCK",
+    EnvLayer.KERNEL,
+    _kt_block,
+    "Code tiles staged per barrier pair in row-blocked GEMM.",
+    default=4,
+    value_help="one of 1, 2, 4, 8, 16, or 32",
+)
+
+ESCHA_MLX_PREFETCH = EnvVar(
+    "ESCHA_MLX_PREFETCH",
+    EnvLayer.KERNEL,
+    _bool,
+    "Prefetch a block of code tiles into registers.",
+    default=False,
+    value_help="a boolean (0/1, false/true, no/yes, or off/on)",
+)
+
+ESCHA_MLX_SORTX = EnvVar(
+    "ESCHA_MLX_SORTX",
+    EnvLayer.KERNEL,
+    _bool,
+    "Pre-sort input rows into expert order for grouped GEMM.",
+    default=False,
+    value_help="a boolean (0/1, false/true, no/yes, or off/on)",
+)
+
+ESCHA_MLX_LINEAR = EnvVar(
+    "ESCHA_MLX_LINEAR",
+    EnvLayer.KERNEL,
+    _choice("fused", "ops"),
+    "Dense coded-linear implementation; the unset default depends on Metal availability.",
+    value_help="one of fused or ops",
+)
+
+ESCHA_MLX_GEMV_PF = EnvVar(
+    "ESCHA_MLX_GEMV_PF",
+    EnvLayer.KERNEL,
+    _positive_int,
+    "Code tiles prefetched by the direct GEMV kernel.",
+    default=1,
+    value_help="a positive integer",
+)
+
+ESCHA_MLX_DENSE_BLOCK_R = EnvVar(
+    "ESCHA_MLX_DENSE_BLOCK_R",
+    EnvLayer.KERNEL,
+    _positive_int,
+    "Rows per group for dense row-blocked GEMM; unset uses the size policy.",
+    value_help="a positive integer",
+)
+
+ESCHA_MLX_DENSE_MAT = EnvVar(
+    "ESCHA_MLX_DENSE_MAT",
+    EnvLayer.KERNEL,
+    _bool,
+    "Use the deterministic, non-bit-identical simdgroup-matrix dense GEMM.",
+    default=False,
+    value_help="a boolean (0/1, false/true, no/yes, or off/on)",
+)
+
+
+# Development inputs --------------------------------------------------------
+
+ESCHA_MODEL = EnvVar(
+    "ESCHA_MODEL",
+    EnvLayer.DEVELOPMENT,
+    _string,
+    "Checkpoint path used by tests and benchmark examples.",
+    value_help="a checkpoint path",
+)
+
+ESCHA_DENSE_MODEL = EnvVar(
+    "ESCHA_DENSE_MODEL",
+    EnvLayer.DEVELOPMENT,
+    _string,
+    "Dense checkpoint path used by checkpoint-dependent tests.",
+    value_help="a checkpoint path",
+)
+
+ESCHA_MLX_SLOW_TESTS = EnvVar(
+    "ESCHA_MLX_SLOW_TESTS",
+    EnvLayer.DEVELOPMENT,
+    _bool,
+    "Opt in to slow, memory-heavy checkpoint tests.",
+    default=False,
+    value_help="a boolean (0/1, false/true, no/yes, or off/on)",
+)
+
+
+_DECLARATIONS = (
+    ESCHA_MLX_WIRED_GB,
+    ESCHA_MLX_GDN_STATE,
+    ESCHA_MLX_LAST_LOGIT,
+    ESCHA_MLX_Q8_GROUP,
+    ESCHA_MLX_BIAS,
+    ESCHA_MLX_DENSE,
+    ESCHA_MLX_MOE,
+    ESCHA_MLX_FUSED_HAD,
+    ESCHA_MLX_LUT,
+    ESCHA_MLX_GEMV,
+    ESCHA_MLX_FETCH,
+    ESCHA_MLX_SPLITK,
+    ESCHA_MLX_BLOCK_R,
+    ESCHA_MLX_KT_BLOCK,
+    ESCHA_MLX_PREFETCH,
+    ESCHA_MLX_SORTX,
+    ESCHA_MLX_LINEAR,
+    ESCHA_MLX_GEMV_PF,
+    ESCHA_MLX_DENSE_BLOCK_R,
+    ESCHA_MLX_DENSE_MAT,
+    ESCHA_MODEL,
+    ESCHA_DENSE_MODEL,
+    ESCHA_MLX_SLOW_TESTS,
+)
+
+environment_variables: dict[str, EnvVar[Any]] = {
+    variable.name: variable for variable in _DECLARATIONS
+}
+
+if len(environment_variables) != len(_DECLARATIONS):  # pragma: no cover
+    raise RuntimeError("duplicate environment variable declaration")
+
+
+def variables_in(layer: EnvLayer) -> tuple[EnvVar[Any], ...]:
+    """Return declarations in one ownership layer, in registry order."""
+    return tuple(variable for variable in _DECLARATIONS if variable.layer is layer)
+
+
+def validate_environment(layers: Iterable[EnvLayer] | None = None) -> None:
+    """Validate all currently set escha variables in the requested layers."""
+    selected = set(EnvLayer if layers is None else layers)
+    for variable in _DECLARATIONS:
+        if variable.layer in selected and variable.is_set():
+            variable.get()

--- a/escha_mlx/envs.py
+++ b/escha_mlx/envs.py
@@ -26,9 +26,14 @@ from typing import Any, Callable, Generic, Iterable, TypeVar, cast
 T = TypeVar("T")
 
 DEFAULT_Q8_GROUP = 128
+GDN_STATE_CHOICES = (
+    "fp16", "float16",
+    "bf16", "bfloat16",
+    "fp32", "float32",
+)
 
 
-class EnvLayer(str, Enum):
+class EnvLayer(Enum):
     """Ownership layer for an environment variable."""
 
     BUILD = "build"
@@ -66,7 +71,7 @@ class EnvVar(Generic[T]):
         such as selecting the Metal MoE backend only when Metal is available.
         """
         raw = os.environ.get(self.name)
-        if raw is None:
+        if raw is None or not raw.strip():
             value = self.default if isinstance(default, _Unset) else default
             return None if isinstance(value, _Unset) else cast(T, value)
         try:
@@ -144,16 +149,10 @@ ESCHA_MLX_WIRED_GB = EnvVar(
 ESCHA_MLX_GDN_STATE = EnvVar(
     "ESCHA_MLX_GDN_STATE",
     EnvLayer.RUNTIME,
-    _choice(
-        "fp16", "float16", "f16",
-        "bf16", "bfloat16",
-        "fp32", "float32", "f32",
-    ),
+    _choice(*GDN_STATE_CHOICES),
     "Storage dtype for the recurrent GDN state.",
     default="fp16",
-    value_help=(
-        "one of f16, fp16, float16, bf16, bfloat16, f32, fp32, or float32"
-    ),
+    value_help=f"one of {', '.join(GDN_STATE_CHOICES)}",
 )
 
 ESCHA_MLX_LAST_LOGIT = EnvVar(
@@ -385,9 +384,16 @@ def variables_in(layer: EnvLayer) -> tuple[EnvVar[Any], ...]:
     return tuple(variable for variable in _DECLARATIONS if variable.layer is layer)
 
 
-def validate_environment(layers: Iterable[EnvLayer] | None = None) -> None:
+def validate_environment(
+    layers: EnvLayer | Iterable[EnvLayer] | None = None,
+) -> None:
     """Validate all currently set escha variables in the requested layers."""
-    selected = set(EnvLayer if layers is None else layers)
+    if layers is None:
+        selected = set(EnvLayer)
+    elif isinstance(layers, EnvLayer):
+        selected = {layers}
+    else:
+        selected = set(layers)
     for variable in _DECLARATIONS:
         if variable.layer in selected and variable.is_set():
             variable.get()

--- a/escha_mlx/gdn_cache.py
+++ b/escha_mlx/gdn_cache.py
@@ -73,10 +73,11 @@ upstream kernel unchanged.
 from __future__ import annotations
 
 import logging
-import os
 
 import mlx.core as mx
 from mlx_lm.models.cache import ArraysCache
+
+from . import envs
 
 logger = logging.getLogger(__name__)
 
@@ -253,10 +254,7 @@ def _restore_upstream_patch() -> None:
 
 def state_dtype() -> mx.Dtype:
     """Storage dtype for the GDN recurrent state (ESCHA_MLX_GDN_STATE)."""
-    v = os.environ.get("ESCHA_MLX_GDN_STATE", "fp16").lower()
-    if v not in _DTYPES:
-        raise ValueError(
-            f"ESCHA_MLX_GDN_STATE must be one of {sorted(set(_DTYPES))}, got {v!r}")
+    v = envs.ESCHA_MLX_GDN_STATE.get()
     return _DTYPES[v]
 
 

--- a/escha_mlx/loader.py
+++ b/escha_mlx/loader.py
@@ -12,14 +12,13 @@ from __future__ import annotations
 import glob
 import json
 import logging
-import os
 import time
 from pathlib import Path
 
 import mlx.core as mx
 import mlx.nn as nn
 
-from . import quant
+from . import envs, quant
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +89,7 @@ def apply_wired_limit() -> float | None:
     unified memory, so it stays the operator's explicit choice rather than
     something a library does behind their back.
     """
-    want = os.environ.get("ESCHA_MLX_WIRED_GB")
+    want = envs.ESCHA_MLX_WIRED_GB.get()
     cap = mx.device_info().get("max_recommended_working_set_size", 0) / 1e9
     if not want:
         logger.info("escha_mlx: wired limit left at MLX's default 0 (nothing "
@@ -98,7 +97,7 @@ def apply_wired_limit() -> float | None:
                     "at high batch, set ESCHA_MLX_WIRED_GB (see loader."
                     "apply_wired_limit)", cap)
         return None
-    gb = float(want)
+    gb = want
     if gb > cap:
         raise ValueError(
             f"ESCHA_MLX_WIRED_GB={gb} exceeds this machine's working-set cap "
@@ -143,7 +142,7 @@ class LastPositionHead(nn.Module):
 def use_last_logit() -> bool:
     """Compute prefill logits for the last position only (ESCHA_MLX_LAST_LOGIT=0
     disables, which is required for per-position scoring)."""
-    return os.environ.get("ESCHA_MLX_LAST_LOGIT", "1") != "0"
+    return bool(envs.ESCHA_MLX_LAST_LOGIT.get())
 
 
 def load_model(path: str | Path):
@@ -157,7 +156,7 @@ def load_model(path: str | Path):
     t0 = time.time()
     config = json.loads((path / "config.json").read_text())
     arch = models.resolve(config)
-    group_size = int(os.environ.get("ESCHA_MLX_Q8_GROUP", str(quant.DEFAULT_GROUP)))
+    group_size = envs.ESCHA_MLX_Q8_GROUP.get()
 
     plugin = arch.CheckpointLoader(config, group_size)
     n_read = 0

--- a/escha_mlx/loader.py
+++ b/escha_mlx/loader.py
@@ -147,6 +147,10 @@ def use_last_logit() -> bool:
 
 def load_model(path: str | Path):
     """Build the model. Returns the mlx-lm Model instance (module-swapped)."""
+    # Fail on malformed process configuration before allocating weights or a
+    # server can report ready and defer the error to its first request.
+    envs.validate_environment()
+
     from . import models   # function-level: plugins import this module
 
     # Before any allocation, so the weights themselves land wired.

--- a/escha_mlx/models/qwen3_5_moe.py
+++ b/escha_mlx/models/qwen3_5_moe.py
@@ -41,14 +41,13 @@ Paths:
 from __future__ import annotations
 
 import logging
-import os
 
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
 from mlx.utils import tree_unflatten
 
-from .. import gdn_cache, moe, msl, quant, ref
+from .. import envs, gdn_cache, moe, msl, quant, ref
 from ..loader import LastPositionHead, resolve_module, strip_lm_prefix, use_last_logit
 
 logger = logging.getLogger(__name__)
@@ -84,15 +83,12 @@ class EschaSparseMoeBlock(nn.Module):
         self.sh_up = quant.make_linear(shared["up_w8"], shared["up_scale"], group_size)
         self.sh_down = quant.make_linear(shared["down_w8"], shared["down_scale"], group_size)
 
-        self._mode = os.environ.get(
-            "ESCHA_MLX_MOE", "fused" if mx.metal.is_available() else "ops")
-        if self._mode not in ("fused", "ops"):
-            raise ValueError(f"ESCHA_MLX_MOE must be 'fused' or 'ops', got {self._mode!r}")
+        self._mode = envs.ESCHA_MLX_MOE.get(
+            default="fused" if mx.metal.is_available() else "ops")
         # ESCHA_MLX_BLOCK_R pins rows-per-group (1 = always the per-row kernel);
         # unset = the size-dependent policy in _blocked_R.
         self._fused_had = msl.use_fused_had() and self._mode == "fused"
-        _br = os.environ.get("ESCHA_MLX_BLOCK_R")
-        self._block_env = int(_br) if _br else None
+        self._block_env = envs.ESCHA_MLX_BLOCK_R.get()
         # Read once at construction: flipping it per-forward would defeat the
         # compile cache and make A/Bs depend on call order.
 

--- a/escha_mlx/msl.py
+++ b/escha_mlx/msl.py
@@ -20,13 +20,12 @@ construction, built by ref.cba_lut on the host).
 """
 from __future__ import annotations
 
-import os
 from functools import lru_cache
 
 import mlx.core as mx
 import numpy as np
 
-from . import ref
+from . import envs, ref
 
 _HEADER = """
 static inline half cba_decode(uint x) {
@@ -740,7 +739,7 @@ def _scaled_had_out_kernel(rs: float, dense: bool = False):
 
 def use_fused_had() -> bool:
     """Fused expert Hadamard transforms (ESCHA_MLX_FUSED_HAD=0 disables)."""
-    return os.environ.get("ESCHA_MLX_FUSED_HAD", "1") != "0"
+    return bool(envs.ESCHA_MLX_FUSED_HAD.get())
 
 
 def scaled_had(rows: mx.array, rin: mx.array, row_expert: mx.array | None,
@@ -785,7 +784,7 @@ def scaled_had_out(mid: mx.array, rout: mx.array, row_expert: mx.array | None,
 
 
 def use_lut() -> bool:
-    return os.environ.get("ESCHA_MLX_LUT", "0") == "1"
+    return bool(envs.ESCHA_MLX_LUT.get())
 
 
 @lru_cache(maxsize=None)
@@ -851,18 +850,12 @@ def gemv_pf() -> int:
     latency-bound kernel -- is hardware-dependent, and this is the cheapest
     lever to re-test on a wider GPU.
     """
-    env = os.environ.get("ESCHA_MLX_GEMV_PF")
-    if not env:
-        return 1
-    pf = int(env)
-    if pf < 1:
-        raise ValueError(f"ESCHA_MLX_GEMV_PF must be >= 1, got {pf}")
-    return pf
+    return int(envs.ESCHA_MLX_GEMV_PF.get())
 
 
 def use_direct() -> bool:
     """Barrier-free per-row GEMV. Default ON; ESCHA_MLX_GEMV=staged reverts."""
-    return os.environ.get("ESCHA_MLX_GEMV", "direct") == "direct"
+    return envs.ESCHA_MLX_GEMV.get() == "direct"
 
 
 def use_shuffle() -> bool:
@@ -887,7 +880,7 @@ def use_shuffle() -> bool:
     hardware-dependent -- issue pressure matters more where there is less
     latency-hiding.  ESCHA_MLX_FETCH=shuffle re-enables it for a retest.
     """
-    return os.environ.get("ESCHA_MLX_FETCH", "load") == "shuffle"
+    return envs.ESCHA_MLX_FETCH.get() == "shuffle"
 
 
 @lru_cache(maxsize=None)
@@ -936,9 +929,9 @@ def split_k_for(m: int, oc: int, tk: int) -> int:
     0.8/core on an 80-core M3 Ultra.  This is the first thing to re-measure
     there; `ESCHA_MLX_SPLITK=auto` turns the policy back on.
     """
-    env = os.environ.get("ESCHA_MLX_SPLITK", "1")
-    if env != "auto":
-        s = int(env)
+    setting = envs.ESCHA_MLX_SPLITK.get()
+    if setting != "auto":
+        s = int(setting)
         return s if s > 1 and tk % s == 0 else 1
     tg = (oc // 128) * m
     if tg >= _SPLIT_TG_TARGET:
@@ -962,7 +955,7 @@ def kt_block() -> int:
     Must divide TK; TK is 128 (gate_up) and 32 (down), so any power of two up
     to 32 is safe.  ESCHA_MLX_KT_BLOCK overrides.
     """
-    return int(os.environ.get("ESCHA_MLX_KT_BLOCK", "4"))
+    return int(envs.ESCHA_MLX_KT_BLOCK.get())
 
 
 def use_prefetch() -> bool:
@@ -982,7 +975,7 @@ def use_prefetch() -> bool:
 
     Costs 2*KB registers per lane on top of acc0[R]/acc1[R].
     """
-    return os.environ.get("ESCHA_MLX_PREFETCH", "0") != "0"
+    return bool(envs.ESCHA_MLX_PREFETCH.get())
 
 
 def use_sortx() -> bool:
@@ -1007,7 +1000,7 @@ def use_sortx() -> bool:
     were.  Kept behind the flag, gated bit-identical, because the memory-
     divergence argument may hold on wider GPUs.
     """
-    return os.environ.get("ESCHA_MLX_SORTX", "0") != "0"
+    return bool(envs.ESCHA_MLX_SORTX.get())
 
 
 @lru_cache(maxsize=None)
@@ -1187,13 +1180,7 @@ def dense_block_r_pin() -> int | None:
     cannot make an A/B depend on call order, and a malformed value fails at
     load instead of from inside the hot loop.
     """
-    env = os.environ.get("ESCHA_MLX_DENSE_BLOCK_R")
-    if not env:
-        return None
-    r = int(env)
-    if r < 1:
-        raise ValueError(f"ESCHA_MLX_DENSE_BLOCK_R must be >= 1, got {r}")
-    return r
+    return envs.ESCHA_MLX_DENSE_BLOCK_R.get()
 
 
 def dense_block_r(m: int, pin: int | None = None) -> int:
@@ -1393,7 +1380,7 @@ def use_dense_mat() -> bool:
     that trade is not worth re-testing here; it is worth re-testing on hardware
     that does.
     """
-    return os.environ.get("ESCHA_MLX_DENSE_MAT", "0") != "0"
+    return bool(envs.ESCHA_MLX_DENSE_MAT.get())
 
 
 def dense_gemm_mat(xh: mx.array, code_u32: mx.array, K: int, IC: int,

--- a/escha_mlx/quant.py
+++ b/escha_mlx/quant.py
@@ -38,11 +38,12 @@ MLX's maximum affine group size, hence the default.
 from __future__ import annotations
 
 import logging
-import os
 
 import mlx.core as mx
 import mlx.nn as nn
 import numpy as np
+
+from . import envs
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,7 @@ _VALIDATED: set[int] = set()
 # MLX affine group sizes, largest first. 128 is the upper bound MLX accepts.
 _GROUPS = (128, 64, 32)
 
-DEFAULT_GROUP = 128
+DEFAULT_GROUP = envs.DEFAULT_Q8_GROUP
 
 
 def fit_group(k: int, requested: int = DEFAULT_GROUP) -> int:
@@ -112,7 +113,7 @@ def validate_pack(group_size: int = DEFAULT_GROUP) -> None:
 
 
 def dense_mode() -> str:
-    return os.environ.get("ESCHA_MLX_DENSE", "q8")
+    return envs.ESCHA_MLX_DENSE.get()
 
 
 class EschaQ8Linear(nn.Module):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-import os
 from pathlib import Path
 
 import numpy as np
 import pytest
 
+from escha_mlx import envs
+
 HERE = Path(__file__).parent
 CODEC = HERE / "data" / "codec"    # format-level goldens (arch-independent)
 ARCH = HERE / "data"               # per-architecture goldens: data/<model_type>/
-DEFAULT_CKPT = os.environ.get(
-    "ESCHA_MODEL", str(Path.home() / "Desktop" / "escha-release-2026-07-16"))
-DENSE_CKPT = os.environ.get(
-    "ESCHA_DENSE_MODEL", str(Path.home() / "Desktop" / "escha-release-27b-2026-08-20"))
+DEFAULT_CKPT = envs.ESCHA_MODEL.get()
+DENSE_CKPT = envs.ESCHA_DENSE_MODEL.get()
 
 
 def has_mlx() -> bool:
@@ -33,14 +32,23 @@ def has_metal() -> bool:
 needs_mlx = pytest.mark.skipif(not has_mlx(), reason="mlx not installed")
 needs_metal = pytest.mark.skipif(not has_metal(), reason="Metal not available")
 needs_ckpt = pytest.mark.skipif(
-    not Path(DEFAULT_CKPT).exists(), reason=f"checkpoint not found: {DEFAULT_CKPT}")
+    not DEFAULT_CKPT or not Path(DEFAULT_CKPT).exists(),
+    reason=(
+        f"checkpoint not found: {DEFAULT_CKPT}"
+        if DEFAULT_CKPT else "ESCHA_MODEL is not set"
+    ),
+)
 needs_dense_ckpt = pytest.mark.skipif(
-    not Path(DENSE_CKPT).exists(),
-    reason=f"dense checkpoint not found: {DENSE_CKPT}")
+    not DENSE_CKPT or not Path(DENSE_CKPT).exists(),
+    reason=(
+        f"dense checkpoint not found: {DENSE_CKPT}"
+        if DENSE_CKPT else "ESCHA_DENSE_MODEL is not set"
+    ),
+)
 # Opt-in: reads real coded weights and peaks around 8 GB RSS. Not something a
 # plain `pytest tests/` on a laptop should start without being asked.
 needs_slow = pytest.mark.skipif(
-    os.environ.get("ESCHA_MLX_SLOW_TESTS") != "1",
+    not envs.ESCHA_MLX_SLOW_TESTS.get(),
     reason="slow/heavy test; set ESCHA_MLX_SLOW_TESTS=1")
 
 

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -1,0 +1,172 @@
+"""Environment registry, parsing, layering, and architecture gates."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from escha_mlx import envs, quant
+
+
+EXPECTED_LAYERS = {
+    envs.EnvLayer.BUILD: set(),
+    envs.EnvLayer.DEPLOYMENT: {"ESCHA_MLX_WIRED_GB"},
+    envs.EnvLayer.RUNTIME: {
+        "ESCHA_MLX_GDN_STATE",
+        "ESCHA_MLX_LAST_LOGIT",
+        "ESCHA_MLX_Q8_GROUP",
+        "ESCHA_MLX_BIAS",
+    },
+    envs.EnvLayer.KERNEL: {
+        "ESCHA_MLX_DENSE",
+        "ESCHA_MLX_MOE",
+        "ESCHA_MLX_FUSED_HAD",
+        "ESCHA_MLX_LUT",
+        "ESCHA_MLX_GEMV",
+        "ESCHA_MLX_FETCH",
+        "ESCHA_MLX_SPLITK",
+        "ESCHA_MLX_BLOCK_R",
+        "ESCHA_MLX_KT_BLOCK",
+        "ESCHA_MLX_PREFETCH",
+        "ESCHA_MLX_SORTX",
+        "ESCHA_MLX_LINEAR",
+        "ESCHA_MLX_GEMV_PF",
+        "ESCHA_MLX_DENSE_BLOCK_R",
+        "ESCHA_MLX_DENSE_MAT",
+    },
+    envs.EnvLayer.DEVELOPMENT: {
+        "ESCHA_MODEL",
+        "ESCHA_DENSE_MODEL",
+        "ESCHA_MLX_SLOW_TESTS",
+    },
+}
+
+
+def _clear_escha_environment(monkeypatch) -> None:
+    for name in envs.environment_variables:
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_registry_has_one_layer_and_description_per_variable():
+    all_layered = set()
+    for layer, expected in EXPECTED_LAYERS.items():
+        actual = {variable.name for variable in envs.variables_in(layer)}
+        assert actual == expected
+        assert not all_layered.intersection(actual)
+        all_layered.update(actual)
+
+    assert all_layered == set(envs.environment_variables)
+    assert all(variable.description for variable in envs.environment_variables.values())
+
+
+def test_defaults_and_call_site_default(monkeypatch):
+    _clear_escha_environment(monkeypatch)
+
+    assert envs.ESCHA_MLX_WIRED_GB.get() is None
+    assert envs.ESCHA_MLX_GDN_STATE.get() == "fp16"
+    assert envs.ESCHA_MLX_LAST_LOGIT.get() is True
+    assert envs.ESCHA_MLX_Q8_GROUP.get() == 128
+    assert envs.ESCHA_MLX_Q8_GROUP.get() == quant.DEFAULT_GROUP
+    assert envs.ESCHA_MLX_BIAS.get() is False
+    assert envs.ESCHA_MLX_DENSE.get() == "q8"
+    assert envs.ESCHA_MLX_MOE.get() is None
+    assert envs.ESCHA_MLX_MOE.get(default="ops") == "ops"
+    assert envs.ESCHA_MLX_SPLITK.get() == 1
+    assert envs.ESCHA_MLX_BLOCK_R.get() is None
+    assert envs.ESCHA_MLX_KT_BLOCK.get() == 4
+    assert envs.ESCHA_MLX_LINEAR.get() is None
+    assert envs.ESCHA_MLX_GEMV_PF.get() == 1
+    assert envs.ESCHA_MLX_DENSE_BLOCK_R.get() is None
+    assert envs.ESCHA_MLX_DENSE_MAT.get() is False
+    assert envs.ESCHA_MODEL.get() is None
+    assert envs.ESCHA_DENSE_MODEL.get() is None
+    assert envs.ESCHA_MLX_SLOW_TESTS.get() is False
+
+
+@pytest.mark.parametrize("raw,want", [
+    ("1", True),
+    ("true", True),
+    ("YES", True),
+    ("on", True),
+    ("0", False),
+    ("false", False),
+    ("NO", False),
+    ("off", False),
+])
+def test_boolean_parsing_is_consistent(monkeypatch, raw, want):
+    monkeypatch.setenv("ESCHA_MLX_FUSED_HAD", raw)
+    assert envs.ESCHA_MLX_FUSED_HAD.get() is want
+
+
+def test_values_are_read_dynamically(monkeypatch):
+    monkeypatch.setenv("ESCHA_MLX_FUSED_HAD", "0")
+    assert envs.ESCHA_MLX_FUSED_HAD.get() is False
+    monkeypatch.setenv("ESCHA_MLX_FUSED_HAD", "1")
+    assert envs.ESCHA_MLX_FUSED_HAD.get() is True
+
+
+@pytest.mark.parametrize("variable,raw,want", [
+    (envs.ESCHA_MLX_GDN_STATE, "FP32", "fp32"),
+    (envs.ESCHA_MLX_GDN_STATE, "BF16", "bf16"),
+    (envs.ESCHA_MLX_Q8_GROUP, "64", 64),
+    (envs.ESCHA_MLX_WIRED_GB, "20.5", 20.5),
+    (envs.ESCHA_MLX_GEMV, "STAGED", "staged"),
+    (envs.ESCHA_MLX_SPLITK, "auto", "auto"),
+    (envs.ESCHA_MLX_SPLITK, "4", 4),
+    (envs.ESCHA_MLX_BLOCK_R, "12", 12),
+    (envs.ESCHA_MLX_KT_BLOCK, "32", 32),
+    (envs.ESCHA_MLX_LINEAR, "OPS", "ops"),
+    (envs.ESCHA_MLX_GEMV_PF, "4", 4),
+    (envs.ESCHA_MLX_DENSE_BLOCK_R, "16", 16),
+])
+def test_typed_parsing(monkeypatch, variable, raw, want):
+    monkeypatch.setenv(variable.name, raw)
+    assert variable.get() == want
+
+
+@pytest.mark.parametrize("variable,raw", [
+    (envs.ESCHA_MLX_FUSED_HAD, "sometimes"),
+    (envs.ESCHA_MLX_GDN_STATE, "int8"),
+    (envs.ESCHA_MLX_DENSE, "int4"),
+    (envs.ESCHA_MLX_MOE, "fast"),
+    (envs.ESCHA_MLX_GEMV, "auto"),
+    (envs.ESCHA_MLX_FETCH, "direct"),
+    (envs.ESCHA_MLX_SPLITK, "0"),
+    (envs.ESCHA_MLX_BLOCK_R, "-1"),
+    (envs.ESCHA_MLX_KT_BLOCK, "3"),
+    (envs.ESCHA_MLX_WIRED_GB, "0"),
+    (envs.ESCHA_MLX_WIRED_GB, "nan"),
+    (envs.ESCHA_MLX_LINEAR, "turbo"),
+    (envs.ESCHA_MLX_GEMV_PF, "0"),
+    (envs.ESCHA_MLX_DENSE_BLOCK_R, "0"),
+])
+def test_invalid_values_name_the_variable(monkeypatch, variable, raw):
+    monkeypatch.setenv(variable.name, raw)
+    with pytest.raises(ValueError, match=variable.name):
+        variable.get()
+
+
+def test_validate_environment_can_be_scoped(monkeypatch):
+    _clear_escha_environment(monkeypatch)
+    monkeypatch.setenv("ESCHA_MLX_GDN_STATE", "invalid")
+    envs.validate_environment([envs.EnvLayer.KERNEL])
+    with pytest.raises(ValueError, match="ESCHA_MLX_GDN_STATE"):
+        envs.validate_environment([envs.EnvLayer.RUNTIME])
+
+
+def test_package_reads_environment_only_through_registry():
+    package = Path(envs.__file__).parent
+    offenders = []
+    for path in package.rglob("*.py"):
+        if path == Path(envs.__file__):
+            continue
+        source = path.read_text()
+        if "os.environ" in source or "os.getenv" in source:
+            offenders.append(path.relative_to(package))
+    assert not offenders, f"direct environment reads outside envs.py: {offenders}"
+
+
+def test_all_registered_variables_are_documented():
+    install = (Path(__file__).parents[1] / "docs" / "INSTALL.md").read_text()
+    missing = [name for name in envs.environment_variables if name not in install]
+    assert not missing, f"environment variables missing from INSTALL.md: {missing}"

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -105,6 +105,15 @@ def test_values_are_read_dynamically(monkeypatch):
     assert envs.ESCHA_MLX_FUSED_HAD.get() is True
 
 
+def test_blank_values_are_treated_as_unset(monkeypatch):
+    monkeypatch.setenv("ESCHA_MLX_BLOCK_R", "")
+    monkeypatch.setenv("ESCHA_MLX_LUT", "  \t")
+
+    assert envs.ESCHA_MLX_BLOCK_R.get() is None
+    assert envs.ESCHA_MLX_LUT.get() is False
+    envs.validate_environment()
+
+
 @pytest.mark.parametrize("variable,raw,want", [
     (envs.ESCHA_MLX_GDN_STATE, "FP32", "fp32"),
     (envs.ESCHA_MLX_GDN_STATE, "BF16", "bf16"),
@@ -149,9 +158,20 @@ def test_invalid_values_name_the_variable(monkeypatch, variable, raw):
 def test_validate_environment_can_be_scoped(monkeypatch):
     _clear_escha_environment(monkeypatch)
     monkeypatch.setenv("ESCHA_MLX_GDN_STATE", "invalid")
-    envs.validate_environment([envs.EnvLayer.KERNEL])
+    envs.validate_environment(envs.EnvLayer.KERNEL)
     with pytest.raises(ValueError, match="ESCHA_MLX_GDN_STATE"):
-        envs.validate_environment([envs.EnvLayer.RUNTIME])
+        envs.validate_environment(envs.EnvLayer.RUNTIME)
+
+
+def test_load_model_validates_environment_before_reading_checkpoint(
+    monkeypatch, tmp_path,
+):
+    from escha_mlx import loader
+
+    _clear_escha_environment(monkeypatch)
+    monkeypatch.setenv("ESCHA_MLX_LUT", "invalid")
+    with pytest.raises(ValueError, match="ESCHA_MLX_LUT"):
+        loader.load_model(tmp_path / "missing")
 
 
 def test_package_reads_environment_only_through_registry():

--- a/tests/test_gdn_state_dtype.py
+++ b/tests/test_gdn_state_dtype.py
@@ -22,32 +22,36 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+from escha_mlx import envs
+
 from .conftest import needs_metal, needs_mlx
 
 pytestmark = needs_mlx
 
 
-def test_state_dtype_env_parsing():
-    import os
+def test_state_dtype_default_and_declarations(monkeypatch):
     import mlx.core as mx
     from escha_mlx import gdn_cache
 
-    saved = os.environ.get("ESCHA_MLX_GDN_STATE")
-    try:
-        os.environ.pop("ESCHA_MLX_GDN_STATE", None)
-        assert gdn_cache.state_dtype() == mx.float16       # measured default
-        for v, want in [("fp16", mx.float16), ("float16", mx.float16),
-                        ("bf16", mx.bfloat16), ("fp32", mx.float32),
-                        ("FP16", mx.float16)]:
-            os.environ["ESCHA_MLX_GDN_STATE"] = v
-            assert gdn_cache.state_dtype() == want, v
-        os.environ["ESCHA_MLX_GDN_STATE"] = "int8"
-        with pytest.raises(ValueError):
-            gdn_cache.state_dtype()
-    finally:
-        os.environ.pop("ESCHA_MLX_GDN_STATE", None)
-        if saved is not None:
-            os.environ["ESCHA_MLX_GDN_STATE"] = saved
+    monkeypatch.delenv("ESCHA_MLX_GDN_STATE", raising=False)
+    assert gdn_cache.state_dtype() == mx.float16       # measured default
+    assert set(envs.GDN_STATE_CHOICES) == set(gdn_cache._DTYPES)
+
+
+@pytest.mark.parametrize("value", envs.GDN_STATE_CHOICES)
+def test_state_dtype_declared_choices(monkeypatch, value):
+    from escha_mlx import gdn_cache
+
+    monkeypatch.setenv("ESCHA_MLX_GDN_STATE", value)
+    assert gdn_cache.state_dtype() == gdn_cache._DTYPES[value]
+
+
+def test_state_dtype_rejects_undeclared_choice(monkeypatch):
+    from escha_mlx import gdn_cache
+
+    monkeypatch.setenv("ESCHA_MLX_GDN_STATE", "f16")
+    with pytest.raises(ValueError, match="ESCHA_MLX_GDN_STATE"):
+        gdn_cache.state_dtype()
 
 
 @pytest.mark.parametrize("dt_name", ["fp16", "bf16"])

--- a/tests/test_mlx_cpu.py
+++ b/tests/test_mlx_cpu.py
@@ -141,8 +141,8 @@ def test_moe_block_ops_vs_ckpt_golden(moeblk_golden):
     """
     from .conftest import DEFAULT_CKPT
     from pathlib import Path
-    if not Path(DEFAULT_CKPT).exists():
-        pytest.skip("checkpoint not available")
+    if not DEFAULT_CKPT or not Path(DEFAULT_CKPT).exists():
+        pytest.skip("checkpoint not available; set ESCHA_MODEL")
 
     import json
     import os


### PR DESCRIPTION
## What

Centralize all ESCHA_* environment variables in a typed registry with consistent defaults, parsing, validation, and ownership layers: build, deployment, runtime, kernel, and development.
This change also:
Migrates package code away from direct os.environ access.
Preserves dynamic reads for in-process benchmarks.
Removes the machine-specific checkpoint fallback in favor of ESCHA_MODEL.
Documents every supported variable and the contribution policy.
Adds tests enforcing registry usage, valid configuration, and documentation coverage.
Validation: 214 passed, 1 skipped (checkpoint test skipped because ESCHA_MODEL was unset).

## Numerics

- [x] Bit-identical: `pytest tests/ -v` green, kernel gates included (paste the Metal gate summary if you touched a kernel)
- [x] OR deliberate numerics change: behind an env flag, previous behavior recoverable, documented in the tuning table in docs/INSTALL.md, validated end-to-end

## Performance (if claimed)

<!-- Paired same-session A/B, baseline re-run as drift control. -->

- Machine: <!-- chip (base/Pro/Max/Ultra), RAM, macOS, mlx version -->
- Numbers: <!-- before / after / drift control; harness used (bench/...) -->

## Checklist

- [x] `pytest tests/ -v` passes locally
- [x] Docs updated where behavior or defaults changed
- [x] Commits signed off (`git commit -s`)
