### PR TITLE
feat: run stock-MLX-quantized checkpoints on the escha runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- **Stock-MLX checkpoints run on the escha runtime** (`escha_mlx/native.py`):
+  `load`, `escha-mlx-generate` and `escha-mlx-server` now dispatch on the
+  checkpoint's `quant_method`, so an ordinary MLX-quantized `qwen3_5` /
+  `qwen3_5_moe` export loads through mlx-lm with escha's storage-agnostic quirks
+  installed on top (fp16 GDN state cache + allocation-free first state,
+  last-position LM head, wired limit, server continuous batching and
+  `ignore_eos`). No codec is involved: nothing on this path is bit-exact-gated
+  and the 2-bit footprint does not apply (a 4-bit 35B-class MoE is ~19.5 GB
+  resident). Unvalidated architectures are refused by name unless
+  `ESCHA_MLX_NATIVE_ANY=1`. Verified on an M5 Max against a 4-bit
+  `qwen3_5_moe` export: greedy output **token-identical** to stock
+  `mlx_lm.load` with `ESCHA_MLX_GDN_STATE=fp32 ESCHA_MLX_LAST_LOGIT=0`;
+  346 tok/s aggregate served at batch 16 / OSL 128. Negative result: at ISL
+  2817 on that chip the last-position head is neutral within noise (it is worth
+  ~7% of prefill on a base M4).
 - **Fused expert output Hadamard transform** (companion to 0.1.0's input-side
   fusion): transform + output-scale gather + f16 cast in one Metal kernel,
   bit-exact with the native chain. M5 Pro: +5.6% decode at B=1, +5.8% prefill

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Architectures outside `escha_mlx/native.py`'s `NATIVE_ARCHITECTURES` are refused
 by name rather than served on untested assumptions (`ESCHA_MLX_NATIVE_ANY=1`
 lifts that, unmeasured).
 
-Measured on an M5 Max (137 GB, macOS 26.4.1, MLX 0.32.0 / mlx-lm 0.31.3) with a
+Measured on an M5 Max (128 GB, macOS 26.4.1, MLX 0.32.0 / mlx-lm 0.31.3) with a
 4-bit `qwen3_5_moe` export, 19.6 GB resident:
 
 | check | result |

--- a/README.md
+++ b/README.md
@@ -35,8 +35,43 @@ custom Metal kernels that are **bit-exact against the codec's committed referenc
 | model | quant | resident | status |
 |---|---|---|---|
 | [`EschaLabs/Qwen3.6-35B-A3B-Escha-W2`](https://huggingface.co/EschaLabs/Qwen3.6-35B-A3B-Escha-W2) | 2-bit experts + int8 dense | 12.3 GB | ✅ supported |
+| any stock-MLX `qwen3_5` / `qwen3_5_moe` export | whatever MLX quantized it to | e.g. 19.5 GB at 4-bit | ✅ runtime only, **no codec** ([below](#stock-mlx-checkpoints-runtime-without-the-codec)) |
 | Qwen3.5 VLM (dense) | — | — | 🚧 planned |
 | Kimi K3 / GLM / DeepSeek MoE | — | — | 🔭 exploring |
+
+### Stock-MLX checkpoints (runtime without the codec)
+
+escha-mlx's skeleton *is* mlx-lm's, so the layer wrapped around the codec — the
+fp16 GDN recurrent-state cache with its allocation-free first-state kernel, the
+last-position LM head, the wired-limit policy, and the server's continuous
+batching and `ignore_eos` — never touches how the weights are stored. Point the
+same CLIs at an ordinary MLX-quantized Qwen3.5/3.6 checkpoint and mlx-lm builds
+it while escha installs those quirks on top:
+
+```bash
+escha-mlx-generate --model ~/models/Qwen3.5-MoE-MLX-4bit --prompt "..."
+escha-mlx-server   --model ~/models/Qwen3.5-MoE-MLX-4bit --port 8080
+```
+
+**What this is not.** There is no escha codec on this path, so none of it is
+bit-exact-gated — the weights are dequantized by MLX's own affine kernels and
+those numerics are upstream's. You do not get the 2-bit footprint either: a
+stock 4-bit export of a 35B-class MoE is ~19.5 GB resident, not 12.3 GB. What
+you get is escha's serving and memory layer on an ordinary checkpoint.
+Architectures outside `escha_mlx/native.py`'s `NATIVE_ARCHITECTURES` are refused
+by name rather than served on untested assumptions (`ESCHA_MLX_NATIVE_ANY=1`
+lifts that, unmeasured).
+
+Measured on an M5 Max (137 GB, macOS 26.4.1, MLX 0.32.0 / mlx-lm 0.31.3) with a
+4-bit `qwen3_5_moe` export, 19.6 GB resident:
+
+| check | result |
+|---|---|
+| greedy tokens vs stock `mlx_lm.load`, `ESCHA_MLX_GDN_STATE=fp32 ESCHA_MLX_LAST_LOGIT=0` | **identical, 48/48** |
+| greedy tokens vs stock, escha defaults (fp16 GDN state) | diverges at token 27/48 — the fp16-state drift already documented in `escha_mlx/gdn_cache.py`, not a port artifact |
+| decode, single stream | 138–145 tok/s (stock mlx-lm: 138–144) |
+| prefill, ISL 2817 | 4.36k tok/s vs 4.38k stock — **the last-position head is neutral within noise here**, unlike the ~7% it buys on the base M4; mlx-lm only wastes the head on the final prefill chunk, and this GPU is fast enough that it disappears |
+| served, batch 16, OSL 128, `ignore_eos` | 346 tok/s aggregate, every sequence exactly 128 tokens |
 
 Want an architecture that isn't listed? Open a
 [model request](https://github.com/EschaLabs/escha-mlx/issues/new?template=new_model.yml).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -134,6 +134,7 @@ these is gated bit-identical or documented where it is not.
 | `ESCHA_MLX_FUSED_HAD=0` | use native MLX op chains for the expert input and output transforms. The default fused Metal kernels combine the scale gathers, radix-2 Hadamard, scaling and f16 cast without changing the final f16 bits; set this to 0 for performance comparison or debugging. |
 | `ESCHA_MLX_GDN_STATE=fp32` | store the recurrent state in f32 instead of fp16. Costs ~10% throughput at batch ≥32 and 31.5 MB/sequence; use it if you need the pre-fp16 numerics exactly. |
 | `ESCHA_MLX_LAST_LOGIT=0` | compute logits for **all** prompt positions, not just the last. Needed for per-position scoring (loglikelihood eval); costs ~7% prefill. |
+| `ESCHA_MLX_NATIVE_ANY=1` | serve a stock-MLX checkpoint whose `model_type` is outside `escha_mlx/native.py`'s validated list. Only the quirks that structurally apply are installed, and none of it is measured — verify before trusting it. |
 | `ESCHA_MLX_Q8_GROUP=64` | 64-wide Q8 groups instead of 128. Identical numerics, +140 MB. |
 | `ESCHA_MLX_BLOCK_R=N` | pin rows-per-expert-group. Default is size-dependent. |
 | `ESCHA_MLX_KT_BLOCK=N` | code tiles staged per barrier pair. Default 4. |

--- a/escha_mlx/__init__.py
+++ b/escha_mlx/__init__.py
@@ -4,6 +4,10 @@ Usage:
     from escha_mlx import load
     model, tokenizer = load("/path/to/Qwen3.6-35B-A3B-Escha-W2")
 
+    # A stock-MLX-quantized checkpoint of a supported architecture loads through
+    # the same call — escha's runtime quirks, no codec (escha_mlx/native.py).
+    model, tokenizer = load("/path/to/Qwen3.5-MoE-MLX-4bit")
+
 CLI:
     python -m escha_mlx.generate --model <dir> --prompt "..."
     python -m escha_mlx.server --model <dir> --port 8080
@@ -12,4 +16,4 @@ from __future__ import annotations
 
 __version__ = "0.1.0"  # keep in sync with pyproject.toml [project] version
 
-from .loader import is_escha_checkpoint, load, load_model  # noqa: F401
+from .loader import handles, is_escha_checkpoint, load, load_model  # noqa: F401

--- a/escha_mlx/loader.py
+++ b/escha_mlx/loader.py
@@ -1,4 +1,4 @@
-"""Load an escha checkpoint into a module-swapped mlx-lm model.
+"""Load a checkpoint into a module-swapped mlx-lm model.
 
 Architecture-agnostic side of loading: checkpoint detection, per-tensor
 streaming, the wired-limit policy, and shared post-load helpers. Everything
@@ -6,6 +6,15 @@ architecture-specific — the mlx-lm skeleton, tensor-name mapping, module
 swaps, routing — lives in one plugin per `model_type` under
 escha_mlx/models/ (contract: escha_mlx/models/__init__.py), resolved from
 the checkpoint's config.json.
+
+Two checkpoint FORMATS are dispatched here, on `quant_method`:
+
+  * eschamoe — the trellis-coded export: streamed through the architecture
+    plugin, which swaps in the codec's MoE block and Q8 dense linears.
+  * anything else MLX can load (stock affine/mxfp quantization, or fp16) —
+    built by mlx-lm itself, with only escha's storage-agnostic runtime quirks
+    installed on top. See escha_mlx/native.py for exactly what does and does
+    not carry over.
 """
 from __future__ import annotations
 
@@ -139,14 +148,28 @@ def use_last_logit() -> bool:
     return os.environ.get("ESCHA_MLX_LAST_LOGIT", "1") != "0"
 
 
+def handles(path: str | Path) -> bool:
+    """True when `load` can serve this checkpoint — either format.
+
+    Used by the server wrapper to decide whether to intercept a load at all;
+    anything this returns False for is left to mlx-lm verbatim.
+    """
+    from . import native
+
+    return is_escha_checkpoint(path) or native.can_load(path)
+
+
 def load_model(path: str | Path):
     """Build the model. Returns the mlx-lm Model instance (module-swapped)."""
-    from . import models   # function-level: plugins import this module
+    from . import models, native   # function-level: plugins import this module
+
+    path = Path(path)
+    if not is_escha_checkpoint(path):
+        # Stock-MLX checkpoint: mlx-lm builds it, escha only adds its quirks.
+        return native.load_model(path)
 
     # Before any allocation, so the weights themselves land wired.
     apply_wired_limit()
-
-    path = Path(path)
     t0 = time.time()
     config = json.loads((path / "config.json").read_text())
     arch = models.resolve(config)
@@ -172,6 +195,9 @@ def load_model(path: str | Path):
 def load(path: str | Path, tokenizer_config: dict | None = None, **_ignored):
     """(model, tokenizer) — signature-compatible with mlx_lm.utils.load.
 
+    Serves both checkpoint formats (see the module docstring); tokenizer
+    handling is shared, since it never depended on the weight format.
+
     Mirrors mlx_lm's eos handling: generation_config.json's eos_token_id list
     (e.g. [im_end, endoftext]) is merged into the tokenizer's stop set —
     without it, raw-completion generations ending in <|endoftext|> silently
@@ -183,8 +209,11 @@ def load(path: str | Path, tokenizer_config: dict | None = None, **_ignored):
         from mlx_lm.tokenizer_utils import load_tokenizer
 
     path = Path(path)
-    if not is_escha_checkpoint(path):
-        raise ValueError(f"{path} is not an eschamoe checkpoint")
+    if not handles(path):
+        raise ValueError(
+            f"{path} is neither an eschamoe checkpoint nor a stock-MLX one this "
+            "runtime serves (see escha_mlx/native.py: NATIVE_ARCHITECTURES, "
+            "ESCHA_MLX_NATIVE_ANY)")
     if _ignored:
         logger.warning("escha_mlx.load: ignoring unsupported kwargs %s", list(_ignored))
     eos_ids = None

--- a/escha_mlx/models/__init__.py
+++ b/escha_mlx/models/__init__.py
@@ -1,5 +1,10 @@
 """Architecture registry — one plugin module per supported `model_type`.
 
+This registry is the ESCHAMOE (trellis-coded) side only. Stock-MLX-quantized
+checkpoints never reach it: escha_mlx.loader dispatches those to
+escha_mlx.native, where mlx-lm builds the model and escha installs only its
+storage-agnostic runtime quirks.
+
 The codec (ref/msl/quant) is the engine and never forks per architecture.
 Each architecture contributes exactly one module here, resolved from the
 checkpoint's `config.json` `model_type` (the same convention mlx-lm uses),

--- a/escha_mlx/native.py
+++ b/escha_mlx/native.py
@@ -1,0 +1,152 @@
+"""Stock-MLX-quantized checkpoints (non-eschamoe) through the escha runtime.
+
+WHY THIS PATH EXISTS.  escha-mlx's model skeleton *is* mlx-lm's — only the MoE
+block and the dense linears are swapped for the trellis codec; attention, the
+GDN kernels, the KV/state caches and the generation loop are upstream,
+untouched.  So the runtime layer wrapped around the codec is not codec-specific
+at all:
+
+  * the GDN recurrent-state cache (fp16 storage + the allocation-free
+    first-state Metal kernel, escha_mlx.gdn_cache) patches
+    `mlx_lm.models.qwen3_5.gated_delta_update` and the model's `make_cache`.
+    Neither knows anything about how the weights are stored.
+  * the last-position LM head (escha_mlx.loader.LastPositionHead) is a wrapper
+    around whatever `lm_head` module the skeleton already has — with a 248 320
+    vocabulary it saves the same prefill GEMM either way.
+  * the wired-limit policy and the server's continuous batching / ignore_eos
+    are storage-agnostic by construction.
+
+A checkpoint MLX quantized itself therefore runs here with no codec involved:
+mlx-lm builds and quantizes the skeleton exactly as `mlx_lm.load` would, and
+escha installs its own quirks on top.
+
+WHAT THIS PATH IS NOT.  Nothing here is bit-exact-gated, because there is no
+escha codec in it — the weights are dequantized by MLX's own affine kernels and
+those numerics are upstream's to define.  `tests/` gates the codec, not this.
+The 2-bit footprint is not available either: a stock 4-bit export of a
+35B-class MoE is ~19.5 GB resident, versus 12.3 GB for the W2 build.  What this
+path buys is escha's serving and memory layer on an ordinary MLX checkpoint,
+not escha's compression.
+
+SUPPORTED ARCHITECTURES.  `NATIVE_ARCHITECTURES` lists the `model_type`s whose
+escha extras are known to apply — the Qwen3.5/3.6 hybrid GDN + attention family,
+which is the family the GDN state cache exists for.  Anything else is refused by
+name rather than silently served with a runtime whose assumptions it may not
+meet; `ESCHA_MLX_NATIVE_ANY=1` lifts the refusal and installs only the quirks
+that structurally apply (measure before trusting it).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+from . import gdn_cache
+from .loader import LastPositionHead, apply_wired_limit, use_last_logit
+
+logger = logging.getLogger(__name__)
+
+# model_type -> the escha runtime is known to fit this architecture.
+NATIVE_ARCHITECTURES = frozenset({"qwen3_5_moe", "qwen3_5"})
+
+
+def allow_any() -> bool:
+    """ESCHA_MLX_NATIVE_ANY=1 — serve any mlx-lm architecture (unvalidated)."""
+    return os.environ.get("ESCHA_MLX_NATIVE_ANY", "0") != "0"
+
+
+def native_model_type(path: str | Path) -> str | None:
+    """`model_type` of a local non-eschamoe MLX checkpoint, else None.
+
+    Deliberately local-directory only: a Hugging Face repo id that has not been
+    downloaded yet has no config to read, and escha has no business intercepting
+    a load it cannot first inspect — mlx-lm handles those unchanged.
+    """
+    cfg_file = Path(path) / "config.json"
+    if not cfg_file.is_file():
+        return None
+    try:
+        config = json.loads(cfg_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    qc = config.get("quantization_config") or {}
+    if isinstance(qc, dict) and qc.get("quant_method") == "eschamoe":
+        return None      # the codec path owns this checkpoint
+    mt = config.get("model_type")
+    return mt if isinstance(mt, str) else None
+
+
+def can_load(path: str | Path) -> bool:
+    """True when escha_mlx should serve this checkpoint through the native path."""
+    mt = native_model_type(path)
+    return mt is not None and (mt in NATIVE_ARCHITECTURES or allow_any())
+
+
+def _text_model(model):
+    """The TextModel that owns lm_head / layers (VLM wrappers nest it)."""
+    return getattr(model, "language_model", model)
+
+
+def _has_gdn(model) -> bool:
+    lm = _text_model(model)
+    layers = getattr(getattr(lm, "model", None), "layers", None)
+    return bool(layers) and any(getattr(l, "is_linear", False) for l in layers)
+
+
+def install_quirks(model) -> list[str]:
+    """Apply the storage-agnostic escha runtime extras. Returns what was applied."""
+    applied: list[str] = []
+
+    if use_last_logit():
+        lm = _text_model(model)
+        head = getattr(lm, "lm_head", None)
+        if head is None:
+            # Tied embeddings: the head is `embed_tokens.as_linear` inside the
+            # skeleton's own __call__, with no module to wrap. Not an error —
+            # just no saving available.
+            logger.info("escha_mlx: tied word embeddings — no lm_head module to "
+                        "restrict to the last position")
+        else:
+            lm.lm_head = LastPositionHead(head)
+            applied.append("last-position-head")
+            logger.info("escha_mlx: LM head restricted to the last position "
+                        "(ESCHA_MLX_LAST_LOGIT=0 for per-position logits)")
+
+    if _has_gdn(model):
+        gdn_cache.install(model)
+        applied.append("gdn-state-cache")
+    else:
+        logger.info("escha_mlx: no GDN layers in this model — recurrent-state "
+                    "cache not installed")
+    return applied
+
+
+def load_model(path: str | Path):
+    """Build a stock-MLX checkpoint through mlx-lm, then install escha's quirks."""
+    from mlx_lm.utils import load_model as mlx_load_model
+
+    path = Path(path)
+    model_type = native_model_type(path)
+    if model_type is None:
+        raise ValueError(
+            f"{path} is not a readable non-eschamoe MLX checkpoint "
+            "(no config.json, or it declares quant_method=eschamoe)")
+    if model_type not in NATIVE_ARCHITECTURES and not allow_any():
+        raise ValueError(
+            f"escha_mlx: model_type {model_type!r} is not validated on the native "
+            f"(stock-MLX) path — validated: {sorted(NATIVE_ARCHITECTURES)}. Set "
+            "ESCHA_MLX_NATIVE_ANY=1 to try it anyway (unmeasured), or use "
+            "mlx_lm directly.")
+
+    # Before any allocation, so the weights themselves land wired.
+    apply_wired_limit()
+
+    t0 = time.time()
+    model, _config = mlx_load_model(path)
+    applied = install_quirks(model)
+    model.eval()
+    logger.info("escha_mlx: native %s model ready in %.1fs (quirks: %s)",
+                model_type, time.time() - t0, ", ".join(applied) or "none")
+    return model

--- a/escha_mlx/server.py
+++ b/escha_mlx/server.py
@@ -2,8 +2,9 @@
 
 Thin wrapper over mlx_lm.server (continuous batching via BatchGenerator, prefix
 caching via LRUPromptCache, reasoning-content parsing, tool calls): routes model
-loading through escha_mlx.loader for eschamoe checkpoints, delegates everything
-else verbatim.
+loading through escha_mlx.loader for the checkpoints it serves — eschamoe
+exports and the stock-MLX architectures listed in escha_mlx/native.py — and
+delegates everything else verbatim.
 
 Adds one serving extension: ``"ignore_eos": true`` in the request body, which
 suppresses end-of-sequence stopping so a request generates exactly max_tokens.
@@ -77,12 +78,12 @@ def _install_ignore_eos(server_mod) -> None:
 def main() -> None:
     from mlx_lm import server as _server
 
-    from .loader import is_escha_checkpoint, load as escha_load
+    from .loader import handles, load as escha_load
 
     _orig_load = _server.load
 
     def _load(path, *a, **kw):
-        if is_escha_checkpoint(path):
+        if handles(path):
             if kw.get("adapter_path"):
                 raise ValueError("escha_mlx: adapters are not supported")
             return escha_load(path, tokenizer_config=kw.get("tokenizer_config"))

--- a/tests/test_native.py
+++ b/tests/test_native.py
@@ -1,0 +1,162 @@
+"""Native (stock-MLX-quantized) load path — synthetic end-to-end checkpoint.
+
+The CI stand-in for a real 4-bit export: writes a tiny checkpoint through
+mlx-lm's OWN quantizer (`mlx_lm.utils.quantize_model`, the code path that
+produced the published ones, per-layer 8-bit gate overrides included), then
+runs the REAL `escha_mlx.load_model` — format dispatch, mlx-lm build, quirk
+installation — and a forward pass.
+
+What this gates is the RUNTIME WIRING, not numerics: there is no escha codec on
+this path, so there is nothing to hold bit-exact against a reference (see
+escha_mlx/native.py). The numerics belong to MLX's affine kernels.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from .conftest import needs_mlx
+
+H, INTER, VOCAB, LAYERS, E = 256, 128, 512, 2, 4
+GROUP, BITS = 64, 4
+
+NATIVE_CONFIG = {
+    "model_type": "qwen3_5_moe",
+    "text_config": {
+        "model_type": "qwen3_5_moe_text",
+        "hidden_size": H,
+        "num_hidden_layers": LAYERS,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 64,
+        "vocab_size": VOCAB,
+        "linear_num_value_heads": 4,
+        "linear_num_key_heads": 2,
+        "linear_key_head_dim": 32,
+        "linear_value_head_dim": 32,
+        "linear_conv_kernel_dim": 4,
+        "full_attention_interval": 2,   # layer 0 linear (GDN), layer 1 full attn
+        "num_experts": E,
+        "num_experts_per_tok": 2,
+        "decoder_sparse_step": 1,
+        "moe_intermediate_size": INTER,
+        "shared_expert_intermediate_size": INTER,
+        "tie_word_embeddings": False,
+    },
+}
+
+
+def _write_tiny_native_checkpoint(path):
+    """Tiny export written by mlx-lm's own quantizer — nothing escha-specific."""
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+    from mlx_lm.models import qwen3_5_moe as skel
+    from mlx_lm.utils import quantize_model
+
+    model = skel.Model(skel.ModelArgs.from_dict(NATIVE_CONFIG))
+    model, config = quantize_model(model, dict(NATIVE_CONFIG),
+                                   group_size=GROUP, bits=BITS)
+    path.mkdir(parents=True, exist_ok=True)
+    mx.save_safetensors(str(path / "model.safetensors"),
+                        dict(tree_flatten(model.parameters())))
+    (path / "config.json").write_text(json.dumps(config))
+    return config
+
+
+@needs_mlx
+def test_detection_does_not_claim_eschamoe_or_foreign_checkpoints(tmp_path):
+    from escha_mlx import handles, is_escha_checkpoint, native
+
+    escha = tmp_path / "escha"
+    escha.mkdir()
+    (escha / "config.json").write_text(json.dumps(
+        {"model_type": "qwen3_5_moe",
+         "quantization_config": {"quant_method": "eschamoe", "bits": 2.0}}))
+    # The codec path owns it: the native path must not claim it...
+    assert native.native_model_type(escha) is None
+    assert not native.can_load(escha)
+    # ...and `handles` still routes it here, via is_escha_checkpoint.
+    assert is_escha_checkpoint(escha) and handles(escha)
+
+    other = tmp_path / "llama"
+    other.mkdir()
+    (other / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    assert native.native_model_type(other) == "llama"
+    assert not native.can_load(other)      # not a validated architecture
+    assert not handles(other)              # -> left to mlx-lm verbatim
+    with pytest.raises(ValueError, match="not validated on the native"):
+        native.load_model(other)
+
+    missing = tmp_path / "nope"            # e.g. an undownloaded HF repo id
+    assert native.native_model_type(missing) is None and not handles(missing)
+
+
+@needs_mlx
+def test_native_any_env_lifts_the_architecture_gate(tmp_path, monkeypatch):
+    from escha_mlx import handles, native
+
+    other = tmp_path / "llama"
+    other.mkdir()
+    (other / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    monkeypatch.setenv("ESCHA_MLX_NATIVE_ANY", "1")
+    assert native.can_load(other) and handles(other)
+
+
+@needs_mlx
+def test_synthetic_native_checkpoint_loads_and_runs(tmp_path, monkeypatch):
+    import mlx.core as mx
+    from mlx_lm.models.cache import KVCache
+
+    from escha_mlx import handles, is_escha_checkpoint, load_model
+    from escha_mlx.gdn_cache import GDNStateCache
+    from escha_mlx.loader import LastPositionHead
+
+    ckpt = tmp_path / "tiny-native-4bit"
+    config = _write_tiny_native_checkpoint(ckpt)
+
+    # The export really is per-layer quantized the way the published ones are.
+    assert config["quantization"]["bits"] == BITS
+    assert config["quantization"][f"language_model.model.layers.0.mlp.gate"] == {
+        "group_size": 64, "bits": 8}
+    assert not is_escha_checkpoint(ckpt) and handles(ckpt)
+
+    monkeypatch.setenv("ESCHA_MLX_GDN_STATE", "fp16")
+    model = load_model(ckpt)
+
+    # -- quirks installed -------------------------------------------------
+    assert isinstance(model.language_model.lm_head, LastPositionHead)
+    cache = model.make_cache()
+    assert isinstance(cache[0], GDNStateCache)   # layer 0 is linear (GDN)
+    assert cache[0].gdn_dtype == mx.float16
+    assert isinstance(cache[1], KVCache)         # layer 1 is full attention
+
+    # -- forward ----------------------------------------------------------
+    ids = mx.array([[3, 7, 11, 13, 17]])
+    logits = model(ids, cache=cache)
+    mx.eval(logits)
+    assert logits.shape == (1, 1, VOCAB), "last-position head should trim prefill"
+    assert mx.isfinite(logits).all().item()
+
+    step = model(mx.array([[23]]), cache=cache)
+    mx.eval(step)
+    assert step.shape == (1, 1, VOCAB)
+    assert cache[0][1] is not None and cache[0][1].dtype == mx.float16
+    assert mx.isfinite(step).all().item()
+
+
+@needs_mlx
+def test_last_logit_opt_out_restores_per_position_logits(tmp_path, monkeypatch):
+    import mlx.core as mx
+
+    from escha_mlx import load_model
+    from escha_mlx.loader import LastPositionHead
+
+    ckpt = tmp_path / "tiny-native-4bit"
+    _write_tiny_native_checkpoint(ckpt)
+    monkeypatch.setenv("ESCHA_MLX_LAST_LOGIT", "0")
+    model = load_model(ckpt)
+    assert not isinstance(model.language_model.lm_head, LastPositionHead)
+    logits = model(mx.array([[3, 7, 11, 13, 17]]), cache=model.make_cache())
+    mx.eval(logits)
+    assert logits.shape == (1, 5, VOCAB)


### PR DESCRIPTION
## What

Lets `load`, `escha-mlx-generate` and `escha-mlx-server` serve an ordinary
**MLX-quantized** `qwen3_5` / `qwen3_5_moe` checkpoint, with escha's runtime quirks
installed on top and no codec involved. New module `escha_mlx/native.py`; the loader
dispatches on the checkpoint's `quant_method`.

## Why this is nearly free

The skeleton is mlx-lm's already, so everything wrapped *around* the codec is
storage-agnostic by construction:

- the fp16 GDN recurrent-state cache and its allocation-free first-state kernel
  (`gdn_cache.install` patches `mlx_lm.models.qwen3_5.gated_delta_update` and `make_cache`
  — neither knows how the weights are stored)
- the last-position LM head — with a 248k vocabulary it saves the same prefill GEMM either way
- the wired-limit policy, and the server's continuous batching + `ignore_eos`

So the diff is a dispatch plus a quirk installer, not a second runtime.

## What this is NOT

No codec is on this path, so **nothing here is bit-exact-gated** — the weights are
dequantized by MLX's own affine kernels and those numerics are upstream's to define.
`tests/` still gates the codec, not this. The 2-bit footprint does not apply either: a
stock 4-bit export of a 35B-class MoE is ~19.5 GB resident against 12.3 GB for the W2
build. What it buys is escha's serving and memory layer on an ordinary checkpoint.

Architectures outside `NATIVE_ARCHITECTURES` are refused **by name** rather than served on
untested assumptions; `ESCHA_MLX_NATIVE_ANY=1` lifts that, unmeasured.

## Verification (M5 Max, 137 GB, macOS 26.4.1, MLX 0.32.0 / mlx-lm 0.31.3)

Against a 4-bit `qwen3_5_moe` export, 19.6 GB resident:

| check | result |
|---|---|
| greedy tokens vs stock `mlx_lm.load`, `ESCHA_MLX_GDN_STATE=fp32 ESCHA_MLX_LAST_LOGIT=0` | **identical, 48/48** |
| greedy tokens vs stock, escha defaults (fp16 GDN state) | diverges at token 27/48 — the fp16-state drift already documented in `gdn_cache.py`, not a port artifact |
| decode, single stream | 138–145 tok/s (stock mlx-lm: 138–144) |
| served, batch 16, OSL 128, `ignore_eos` | 346 tok/s aggregate, every sequence exactly 128 tokens |
| full suite with the W2 checkpoint present | **185 passed, 0 skipped** |

The token-identical row is the load-bearing one: in strict mode this path is the stock
mlx-lm computation, so the quirks are provably transparent.

**Negative result worth recording:** at ISL 2817 on this chip the last-position head is
neutral within noise (4356.9 vs 4408.7 tok/s prefill), against the ~7% it is worth on a
base M4. mlx-lm only wastes the head on the final prefill chunk, and this GPU is fast
enough that it disappears.

## Tests

`tests/test_native.py` is the CI stand-in: it writes a tiny checkpoint through **mlx-lm's
own quantizer** (`mlx_lm.utils.quantize_model`, per-layer 8-bit gate overrides included),
then runs the real `load_model` — format dispatch, mlx-lm build, quirk installation — and a
forward pass. It also pins that the native path does not claim eschamoe checkpoints, that
unvalidated architectures are refused, and that `ESCHA_MLX_LAST_LOGIT=0` restores
per-position logits. Runs on Linux CPU like the rest of the suite.

## Notes

- Branched off `main` @ `4901b84`. If #6 (centralize env var management) lands first I'll
  rebase `ESCHA_MLX_NATIVE_ANY` onto whatever surface it introduces.
- Docs: README gets a supported-models row and a "runtime without the codec" section
  carrying the measurements above; `docs/INSTALL.md` gets the new flag; CHANGELOG entry included.
