### PR TITLE
server: fix prompt-cache exact-hit hang and batch processor-slot desync

### DIFF
--- a/escha_mlx/gdn_cache.py
+++ b/escha_mlx/gdn_cache.py
@@ -281,6 +281,18 @@ class GDNStateCache(ArraysCache):
         """Resolved on access; only the name is stored (see _NAME_OF)."""
         return _DTYPES[self._gdn_dtype_name]
 
+    def is_trimmable(self):
+        # Pinned, not inherited. A recurrent state is position-dependent: it
+        # can be resumed only at exactly the token boundary it was stored at,
+        # never rewound. Today this returns False anyway via _BaseCache, but
+        # the server's prompt-cache reuse gate (can_trim_prompt_cache) trusts
+        # this answer to decide whether a LONGER cached sequence may be
+        # trimmed back and reused for a shorter prompt -- if a future mlx-lm
+        # taught ArraysCache to "trim", that gate would silently hand a
+        # position-shifted GDN state to every supersequence request. Refusing
+        # here can only force a full prefill, which is byte-equal to cold.
+        return False
+
     def __setitem__(self, idx, value):
         if idx == _STATE_SLOT and value is not None and value.dtype != self.gdn_dtype:
             value = value.astype(self.gdn_dtype)

--- a/escha_mlx/server.py
+++ b/escha_mlx/server.py
@@ -132,6 +132,46 @@ def _install_exact_hit_guard() -> None:
     lru.fetch_nearest_cache = fetch_nearest_cache
 
 
+def _install_slot_realign_guard() -> None:
+    """Keep per-request samplers/logits_processors aligned with uids.
+
+    mlx_lm 0.31.3's ``GenerationBatch.filter`` reindexes ``samplers`` and
+    ``logits_processors`` only when ``any(...)`` is truthy. A batch whose
+    requests all lack processors carries ``[[], [], ...]`` — all falsy — so
+    on request completion the list keeps its STALE length while ``uids``
+    shrinks; the next ``extend()`` then appends the incoming request's
+    processors positionally, and from that point every per-request processor
+    (and, for temp>0, sampler) reads the wrong slot. Reachable today with
+    upstream's own per-request ``logit_bias`` / ``repetition_penalty``: a
+    plain request finishing ahead of one that carries them leaves theirs
+    attached to the wrong sequence. (The sibling
+    ``PromptProcessingBatch.filter`` has the correct else-branch
+    normalization; this brings ``GenerationBatch`` to parity.) Realigning
+    after the fact is safe precisely because the guard only ever fires when
+    every entry is falsy — there is no information in the stale list to
+    lose.
+    """
+    # NB: `from mlx_lm import generate` yields the re-exported FUNCTION that
+    # shadows the submodule of the same name; the module path form below
+    # resolves the module.
+    from mlx_lm.generate import GenerationBatch as gb
+
+    if getattr(gb.filter, "_escha_slot_realign", False):
+        return
+    orig = gb.filter
+
+    def filter(self, keep):
+        orig(self, keep)
+        n = len(self.uids)
+        if len(self.samplers) != n:
+            self.samplers = [None] * n
+        if len(self.logits_processors) != n:
+            self.logits_processors = [[] for _ in range(n)]
+
+    filter._escha_slot_realign = True
+    gb.filter = filter
+
+
 def main() -> None:
     from mlx_lm import server as _server
 
@@ -149,6 +189,7 @@ def main() -> None:
     _server.load = _load
     _install_ignore_eos(_server)
     _install_exact_hit_guard()
+    _install_slot_realign_guard()
     sys.argv[0] = "escha_mlx.server"
     _server.main()
 

--- a/escha_mlx/server.py
+++ b/escha_mlx/server.py
@@ -74,6 +74,64 @@ def _install_ignore_eos(server_mod) -> None:
     handler.validate_model_parameters = validate_model_parameters
 
 
+def _install_exact_hit_guard() -> None:
+    """Never let the prompt cache return an empty remainder.
+
+    mlx_lm 0.31.3's ``LRUPromptCache.fetch_nearest_cache`` answers an EXACT
+    key hit with ``(deepcopy(cache), [])``.  Both serving paths assume at
+    least one prompt token remains: the batched path pops every prompt
+    segment and then indexes ``seq[-1]`` on the empty list
+    (``BatchGenerator.insert_segments``) -- an IndexError that kills the
+    generation thread, after which every request queues forever -- and the
+    sequential path would hand ``stream_generate`` an empty prompt.  The key
+    is ``prompt + generated`` of a finished request, so a /v1/completions
+    continuation of a previous response hits it in ordinary traffic.
+
+    The guard re-establishes the invariant at the source instead of patching
+    each consumer:
+
+    * trimmable cache (pure-KV models served through this wrapper): trim one
+      token off the copy and re-feed the last prompt token.  This is also the
+      byte-equal choice -- feeding the last token against the full-length
+      cache would advance its state a second time and shift the first
+      generated token's position.
+    * non-trimmable cache (both escha models: GDNStateCache holds recurrent
+      state that only resumes at its exact stored boundary): decline the
+      exact entry and re-resolve the query minus its final token.  That
+      returns a stored key equal to ``tokens[:-1]`` (reused as-is, final
+      token re-fed), a shorter stored prefix, or a cold start -- the
+      full-length entry itself is correctly skipped by the trim gate.  Every
+      arm feeds ``>= 1`` real token and resumes state only at a boundary it
+      was stored at.
+    """
+    from mlx_lm.models import cache as cache_mod
+
+    lru = cache_mod.LRUPromptCache
+    if getattr(lru.fetch_nearest_cache, "_escha_exact_hit_guard", False):
+        return
+    orig = lru.fetch_nearest_cache
+
+    def fetch_nearest_cache(self, model, tokens):
+        cache, rest = orig(self, model, tokens)
+        if cache is None or rest:
+            return cache, rest
+        if len(tokens) < 2:
+            return None, list(tokens)
+        if cache_mod.can_trim_prompt_cache(cache):
+            cache_mod.trim_prompt_cache(cache, 1)
+            return cache, list(tokens[-1:])
+        cache, rest = orig(self, model, tokens[:-1])
+        if cache is None:
+            return None, list(tokens)
+        # `rest` is relative to tokens[:-1]; [] here means tokens[:-1] is
+        # itself a stored key, reusable as-is because the remainder below
+        # feeds the final token against it.
+        return cache, list(rest) + list(tokens[-1:])
+
+    fetch_nearest_cache._escha_exact_hit_guard = True
+    lru.fetch_nearest_cache = fetch_nearest_cache
+
+
 def main() -> None:
     from mlx_lm import server as _server
 
@@ -90,6 +148,7 @@ def main() -> None:
 
     _server.load = _load
     _install_ignore_eos(_server)
+    _install_exact_hit_guard()
     sys.argv[0] = "escha_mlx.server"
     _server.main()
 

--- a/tests/test_batch_slot_realign.py
+++ b/tests/test_batch_slot_realign.py
@@ -1,0 +1,74 @@
+"""Slot-realign guard for GenerationBatch.filter (see server.py).
+
+Upstream reindexes per-request samplers/logits_processors only when
+``any(...)`` is truthy, so an all-falsy processor list keeps a stale length
+when a request finishes and the next ``extend()`` appends positionally —
+misaligning processors (``logit_bias``, ``repetition_penalty``) with uids.
+Exercised against the real mlx-lm GenerationBatch, built structurally with
+no model forward.
+"""
+from __future__ import annotations
+
+import pytest
+
+from .conftest import needs_mlx
+
+mx = pytest.importorskip("mlx.core")
+
+from escha_mlx.server import _install_slot_realign_guard  # noqa: E402
+
+
+def _bare_batch(n: int, processors):
+    from mlx_lm.generate import GenerationBatch
+    b = GenerationBatch.__new__(GenerationBatch)
+    b.uids = list(range(n))
+    b.prompt_cache = []
+    b.tokens = [[i] for i in range(n)]
+    b.samplers = [None] * n
+    b.logits_processors = processors
+    b.max_tokens = [8] * n
+    b.state_machines = [object()] * n
+    b._current_tokens = None
+    b._current_logprobs = None
+    b._next_tokens = mx.zeros((n,), dtype=mx.int32)
+    b._next_logprobs = [None] * n
+    b._token_context = [None] * n
+    b._num_tokens = [0] * n
+    b._matcher_states = [None] * n
+    return b
+
+
+@needs_mlx
+class TestSlotRealignGuard:
+    def test_filter_realigns_all_falsy_processor_list(self):
+        _install_slot_realign_guard()
+        b = _bare_batch(2, [[], []])
+        b.filter([1])
+        assert len(b.uids) == 1
+        assert len(b.logits_processors) == 1      # stale length without guard
+        assert len(b.samplers) == 1
+
+    def test_extend_after_filter_keeps_alignment(self):
+        _install_slot_realign_guard()
+        b = _bare_batch(2, [[], []])
+        b.filter([1])
+        proc = object()
+        other = _bare_batch(1, [[proc]])
+        b.extend(other)
+        # the new request's processor must sit at ITS index, not one past it
+        assert len(b.logits_processors) == len(b.uids) == 2
+        assert b.logits_processors[-1] == [proc]
+
+    def test_truthy_lists_still_reindex_normally(self):
+        _install_slot_realign_guard()
+        p0, p1 = object(), object()
+        b = _bare_batch(2, [[p0], [p1]])
+        b.filter([1])
+        assert b.logits_processors == [[p1]]
+
+    def test_install_is_idempotent(self):
+        from mlx_lm.generate import GenerationBatch
+        _install_slot_realign_guard()
+        first = GenerationBatch.filter
+        _install_slot_realign_guard()
+        assert GenerationBatch.filter is first

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -1,0 +1,140 @@
+"""Prompt-cache safety for the hybrid (GDN + attention) cache lists.
+
+Two invariants, both enforced in escha_mlx code rather than assumed of
+mlx-lm:
+
+* ``GDNStateCache.is_trimmable()`` is pinned False (a recurrent state resumes
+  only at its exact stored boundary), so the server's supersequence-reuse
+  gate can never trim-and-reuse a longer hybrid entry.
+* ``LRUPromptCache.fetch_nearest_cache`` never returns an empty remainder
+  once ``server._install_exact_hit_guard`` runs.  Upstream answers an exact
+  key hit with ``(cache, [])``, which crashes the batched serving path
+  (``seq[-1]`` on an empty segment list) and would hand the sequential path
+  an empty prompt.  The key is ``prompt + generated`` of a finished request,
+  so ordinary continuation traffic reaches it.
+
+The tests drive ``LRUPromptCache`` directly with real cache objects -- no
+checkpoint, no Metal, no server process.
+"""
+from __future__ import annotations
+
+import pytest
+
+from .conftest import needs_mlx
+
+mx = pytest.importorskip("mlx.core")
+
+from mlx_lm.models.cache import KVCache, can_trim_prompt_cache  # noqa: E402
+from mlx_lm.models.cache import LRUPromptCache  # noqa: E402
+
+from escha_mlx.gdn_cache import GDNStateCache  # noqa: E402
+from escha_mlx.server import _install_exact_hit_guard  # noqa: E402
+
+MODEL_KEY = ("model", None, None)
+
+
+def _filled_kv(n_tokens: int) -> KVCache:
+    kv = KVCache()
+    keys = mx.zeros((1, 2, n_tokens, 8), dtype=mx.float16)
+    kv.update_and_fetch(keys, keys)
+    return kv
+
+
+def _hybrid_cache(n_tokens: int) -> list:
+    """One GDN layer + one attention layer, as both escha models produce."""
+    gdn = GDNStateCache(size=2, dtype=mx.float16)
+    gdn[0] = mx.zeros((1, 4, 8), dtype=mx.float16)          # conv state
+    gdn[1] = mx.zeros((1, 2, 8, 8), dtype=mx.float32)       # recurrent state
+    return [gdn, _filled_kv(n_tokens)]
+
+
+@pytest.fixture()
+def guarded_lru() -> LRUPromptCache:
+    _install_exact_hit_guard()
+    return LRUPromptCache(max_size=10)
+
+
+@needs_mlx
+class TestTrimmability:
+    def test_gdn_state_cache_is_not_trimmable(self):
+        assert GDNStateCache(size=2, dtype=mx.float16).is_trimmable() is False
+
+    def test_hybrid_cache_list_cannot_trim(self):
+        assert can_trim_prompt_cache(_hybrid_cache(4)) is False
+
+    def test_is_trimmable_is_pinned_not_inherited(self):
+        # The method must live on the class itself: the invariant may not
+        # silently change with the mlx-lm base class.
+        assert "is_trimmable" in GDNStateCache.__dict__
+
+
+@needs_mlx
+class TestExactHitGuard:
+    def test_install_is_idempotent(self):
+        _install_exact_hit_guard()
+        first = LRUPromptCache.fetch_nearest_cache
+        _install_exact_hit_guard()
+        assert LRUPromptCache.fetch_nearest_cache is first
+
+    def test_exact_hit_hybrid_no_prefix_goes_cold(self, guarded_lru):
+        tokens = list(range(32))
+        guarded_lru.insert_cache(MODEL_KEY, tokens, _hybrid_cache(32))
+        cache, rest = guarded_lru.fetch_nearest_cache(MODEL_KEY, tokens)
+        assert cache is None
+        assert rest == tokens
+
+    def test_exact_hit_hybrid_reuses_stored_shorter_prefix(self, guarded_lru):
+        tokens = list(range(32))
+        guarded_lru.insert_cache(MODEL_KEY, tokens[:16], _hybrid_cache(16))
+        guarded_lru.insert_cache(MODEL_KEY, tokens, _hybrid_cache(32))
+        cache, rest = guarded_lru.fetch_nearest_cache(MODEL_KEY, tokens)
+        assert cache is not None
+        assert rest == tokens[16:]          # never empty, boundary respected
+        assert isinstance(cache[0], GDNStateCache)
+
+    def test_exact_hit_hybrid_reuses_len_minus_one_key(self, guarded_lru):
+        tokens = list(range(32))
+        guarded_lru.insert_cache(MODEL_KEY, tokens[:-1], _hybrid_cache(31))
+        guarded_lru.insert_cache(MODEL_KEY, tokens, _hybrid_cache(32))
+        cache, rest = guarded_lru.fetch_nearest_cache(MODEL_KEY, tokens)
+        assert cache is not None
+        assert rest == tokens[-1:]
+        assert cache[1].offset == 31        # the len-1 entry, untouched
+
+    def test_exact_hit_trimmable_trims_one_and_refeeds_last(self, guarded_lru):
+        tokens = list(range(16))
+        guarded_lru.insert_cache(MODEL_KEY, tokens, [_filled_kv(16)])
+        cache, rest = guarded_lru.fetch_nearest_cache(MODEL_KEY, tokens)
+        assert rest == tokens[-1:]
+        assert cache[0].offset == 15        # trimmed copy...
+        stored, stored_rest = guarded_lru.fetch_nearest_cache(
+            MODEL_KEY, tokens + [99])
+        assert stored[0].offset == 16       # ...stored entry untouched
+        assert stored_rest == [99]
+
+    def test_single_token_exact_hit_goes_cold(self, guarded_lru):
+        guarded_lru.insert_cache(MODEL_KEY, [7], _hybrid_cache(1))
+        cache, rest = guarded_lru.fetch_nearest_cache(MODEL_KEY, [7])
+        assert cache is None
+        assert rest == [7]
+
+    def test_supersequence_of_hybrid_reuses_at_stored_boundary(self, guarded_lru):
+        tokens = list(range(32))
+        guarded_lru.insert_cache(MODEL_KEY, tokens, _hybrid_cache(32))
+        cache, rest = guarded_lru.fetch_nearest_cache(MODEL_KEY, tokens + [1, 2])
+        # Reuse at exactly the stored boundary is the one legal hybrid reuse.
+        assert cache is not None
+        assert rest == [1, 2]
+
+    def test_miss_passes_through(self, guarded_lru):
+        tokens = list(range(8))
+        cache, rest = guarded_lru.fetch_nearest_cache(MODEL_KEY, tokens)
+        assert cache is None
+        assert rest == tokens
+
+    def test_fetch_preserves_gdn_dtype(self, guarded_lru):
+        tokens = list(range(32))
+        guarded_lru.insert_cache(MODEL_KEY, tokens, _hybrid_cache(32))
+        cache, rest = guarded_lru.fetch_nearest_cache(MODEL_KEY, tokens + [5])
+        assert isinstance(cache[0], GDNStateCache)
+        assert cache[0].gdn_dtype == mx.float16


### PR DESCRIPTION
## What

  Two guards for the serving wrapper against mlx-lm 0.31.3 internals it
  delegates to — one theme (batched-serving correctness), no kernels, no
  features:

  1. **Prompt-cache exact-hit guard + `GDNStateCache.is_trimmable()` pin.**
     `LRUPromptCache.fetch_nearest_cache` answers an exact key hit with
     `(deepcopy(cache), [])`; the batched path then indexes `seq[-1]` on an
     empty segment list — an IndexError that kills the generation thread, so
     every subsequent request queues forever. The stored key is
     `prompt + generated` of a finished request, so a `/v1/completions`
     continuation reaches it from ordinary traffic. The guard never returns an
     empty remainder: trimmable caches trim one token and re-feed the last
     prompt token (also the byte-equal choice — full-length reuse would
     double-advance the final position); non-trimmable hybrid caches decline
     the exact entry and re-resolve to a stored boundary or a cold start. The
     trimmability pin makes the supersequence-reuse refusal explicit on the
     class, so a future mlx-lm that teaches `ArraysCache` to trim can't hand
     position-shifted GDN state to supersequence requests.
  2. **`GenerationBatch.filter` slot-realign guard.** Upstream reindexes
     `samplers`/`logits_processors` only when `any(...)` is truthy, so an
     all-falsy processor list keeps a stale length when a request finishes and
     the next `extend()` appends positionally — per-request `logit_bias` /
     `repetition_penalty` end up attached to the wrong sequence. The sibling
     `PromptProcessingBatch.filter` already normalizes; this brings
     `GenerationBatch` to parity.

  Both root causes are upstream mlx-lm bugs (to be reported separately); the
  guards are idempotent and inert once upstream fixes land.

  ## Numerics

  - [x] Bit-identical: `pytest tests/ -v` green (196 passed, 1 skipped),
        kernel gates included — no kernel touched; `bench/p0_gates.py`:
        ALL GATES PASS. The exact-hit guard *restores* byte-equality
        (warm-cache response == cold) rather than changing numerics.
  - [ ] OR deliberate numerics change: n/a

  ## Performance (if claimed)

  No performance claim — pure correctness/robustness. No throughput-relevant
  path changes.

  ## Checklist

  - [x] `pytest tests/ -v` passes locally (196 passed, 1 skipped, M4 base
        24 GB, macOS 26.5.2, mlx 0.32.0, mlx-lm 0.31.3; includes 16 new tests
        in `tests/test_prompt_cache.py` and `tests/test_batch_slot_realign.py`)
  - [x] Docs updated where behavior or defaults changed — no flag or default
        changed; both guards carry full docstrings at the install sites
  - [x] Commits signed off (`git commit -s`)