### PR TITLE
Codex/qwen38 mtp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- **Qwen3.8 native MTP decoding** — opt-in fixed-tree speculative decoding for
+  `Qwen3.8-27B-Escha-W2` across the Python generator, CLI, and continuous-batching
+  server. The checkpoint-native MTP head uses a top-k=3, depth=3 tree and verifies
+  four target positions per round, with per-request path acceptance and cache commit.
+  Batched projection fusion, GDN state tracing, fused tree top-k/logsumexp, and shared
+  proposal-prefix caches keep the implementation on the existing mlx-lm scheduler.
+  Previous-round GDN traces are released before constructing the next tree. On a
+  24 GB M5 Pro, MTP servers default prompt/decode concurrency to 2 and cap the prompt
+  LRU at 512 MB; explicit CLI values still win. Post-fix validation completed 16/16
+  C=8 requests at ISL/OSL 128/96 with no errors or short outputs. A warmed batch-1
+  ABBA measured 21.46 versus 16.63 output tok/s (1.290x); continuous-batch MTP was
+  beneficial at B=1/2 and slower than AR at B=4/8, so it is not presented as a
+  universal batched-decode accelerator. Raw results and the reproducer live under
+  `bench/results/m5-pro-24gb/dense27b_mtp_20260907.json` and `bench/mtp.py`.
 - **M4 bring-up of the dense path** — first execution of the dense Metal kernels on
   hardware. They were bit-exact on arrival: the P0 dense gate (G0.2b), the
   real-checkpoint tests and the correctness battery all passed without a kernel fix.

--- a/README.md
+++ b/README.md
@@ -164,18 +164,39 @@ low-acceptance request no longer shortens the whole batch.
 
 ### Qwen3.8 MTP performance
 
-Batch-1 end-to-end decode on a 24 GB, 16-core-GPU M5 Pro with
-`Qwen3.8-27B-Escha-W2`, macOS 26.6.2, MLX 0.32.0 and mlx-lm 0.31.3. This is a
-256-output-token greedy smoke test after warm-up.
+Batch-1 end-to-end generation on a 24 GB, 16-core-GPU M5 Pro with
+`Qwen3.8-27B-Escha-W2`, macOS 26.6.2, MLX 0.32.0 and mlx-lm 0.31.3, measured at
+revision `b30bb9b`. This is a warmed ABBA run over a 20-token chat prompt and
+256 greedy output tokens; timing includes prefill.
 
 | decode path | latency / output token | output throughput | speedup |
 |---|---:|---:|---:|
-| autoregressive (MTP off) | 59.759 ms | 16.73 tok/s | 1.000x |
-| fixed-tree M4 (MTP on) | 43.880 ms | 22.79 tok/s | **1.362x** |
+| autoregressive (MTP off) | 60.128 ms | 16.63 tok/s | 1.000x |
+| fixed-tree M4 (MTP on) | 46.598 ms | 21.46 tok/s | **1.290x** |
 
-The MTP run emitted 2.931 tokens per target verification round on average.
-Greedy outputs can diverge at near-tied logits, so this measurement is a
-performance regression test rather than a bit-identity assertion.
+The MTP run emitted 2.844 tokens per target verification round on average, and
+both arms produced the same token digest for this prompt.
+
+Continuous-batch decode was measured separately after a 128-token prefill, with
+96 output tokens per request, a fresh process per arm, and warmed ABBA ordering.
+Prefill is excluded from these rows.
+
+| batch | AR output tok/s | MTP output tok/s | MTP / AR | MTP peak |
+|---:|---:|---:|---:|---:|
+| 1 | 17.05 | 19.37 | **1.136x** | 11.60 GB |
+| 2 | 25.30 | 26.49 | **1.047x** | 12.25 GB |
+| 4 | 43.14 | 33.54 | 0.777x | 13.68 GB |
+| 8 | 56.40 | 41.62 | 0.738x | 16.51 GB |
+
+This crossover is why the MTP server defaults decode and prompt concurrency to
+2. An explicit C=8 server stress run (ISL/OSL 128/96, 16 requests) completed all
+requests with no errors or missed output lengths at 17.10 output tok/s after the
+prompt-cache memory fix. The Prompt LRU peaked at 0.44 GB under its 512 MB budget.
+Greedy outputs can still diverge at shape-dependent near ties, so these
+measurements are performance regression checks rather than a general
+bit-identity assertion. Raw ABBA and server evidence is in
+[`bench/results/m5-pro-24gb/dense27b_mtp_20260907.json`](bench/results/m5-pro-24gb/dense27b_mtp_20260907.json);
+reproduce the local generation measurements with [`bench/mtp.py`](bench/mtp.py).
 
 Small-row coded-projection experiments which did not clear the whole-target
 retention gate are recorded in

--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ custom Metal kernels that are **bit-exact against the codec's committed referenc
 
 - **35B-class MoE in 12.3 GB** — generates and serves on a stock 24 GB Mac
 - **OpenAI-compatible server** with continuous batching and prefix caching
-- **Provable correctness**: every kernel path gated `np.array_equal` against committed
-  goldens — not a tolerance. CI runs the suite on every PR (reference/repack gates on
-  Linux CPU; the Metal kernel gates run when the runner exposes Metal and self-skip
-  otherwise — the workflow's "Metal available?" step records which happened)
+- **Qwen3.8 pretrained MTP** with SGLang-shaped tree speculative decoding
+- **Explicit numerical contracts**: codec and coded-projection kernels are gated
+  `np.array_equal` against committed goldens; reassociated acceleration paths are
+  deterministic, tolerance-gated and retain a documented fallback or opt-out. CI
+  runs the suite on every PR (reference/repack gates on Linux CPU; Metal gates run
+  when the runner exposes Metal and self-skip otherwise)
 - **Honest benchmarks**: measured on hardware, drift-controlled, negative results included
 
 > **This is a reference implementation.** The kernels and defaults are correct on any
@@ -69,8 +71,10 @@ work, and the test gates below tell you for sure.
 
 The NumPy reference (`escha_mlx/ref.py`) is the semantic contract, and the golden vectors
 committed under `tests/data/` pin the codec's exact numerics — every fp16 rounding point
-included. Every Metal kernel path — staged GEMV, direct GEMV, row-blocked GEMM, fused
-transform, hash and LUT decode — is gated **bit-identical** to them and to each other:
+included. The codec and coded-projection Metal paths — staged GEMV, direct GEMV,
+row-blocked GEMM, fused transform, hash and LUT decode — are gated **bit-identical**
+to them and to each other. MTP tree/GDN and small-row vocabulary specializations have
+separate deterministic and tolerance gates:
 
 ```bash
 pytest tests/ -v              # full suite — tests self-skip by capability
@@ -89,8 +93,16 @@ generation, then serving.
 # one-shot generation
 escha-mlx-generate --model ~/models/escha-w2 --prompt "Explain unified memory in one paragraph."
 
+# Qwen3.8 native MTP; fixed tree topk=3, depth=3, M=4 verification
+escha-mlx-generate --model ~/models/Qwen3.8-27B-Escha-W2 \
+  --mtp --prompt "Explain speculative decoding."
+
 # OpenAI-compatible server (continuous batching + prefix caching)
 escha-mlx-server --model ~/models/escha-w2 --port 8080 --prefill-step-size 256
+
+# Qwen3.8 native MTP with continuous batching
+escha-mlx-server --model ~/models/Qwen3.8-27B-Escha-W2 --mtp \
+  --port 8080 --prefill-step-size 256
 ```
 
 ```bash
@@ -104,6 +116,70 @@ past the ~19 GB GPU working-set cap), and close memory-hungry apps for the first
 Above a ~18 GB working set, set `ESCHA_MLX_WIRED_GB` — unwired, throughput silently
 collapses 23× near the cap. Memory settings and the full tuning-knob reference:
 [docs/INSTALL.md](docs/INSTALL.md).
+
+MTP is opt-in and disabled by default. Pass `--mtp` to the CLI or server, or
+`load_mtp=True` to the Python loader, to load the checkpoint's MTP head and use
+speculative decoding. Omit the option (the Python default is `False`) to use
+ordinary autoregressive decoding without loading the MTP head.
+
+Native-MTP batching currently requires the standard growing KV cache;
+`MTPBatchGenerator` rejects `max_kv_size` and rotating caches at setup rather
+than failing after the cache fills. The MTP server defaults prompt and decode
+concurrency to 2: tree verification wins at B=1/2 but is slower than ordinary
+batched AR from B=4 onward, while its GDN trace memory scales with the active
+batch. It also caps the prompt-cache budget at 512 MB because B=8 verification
+and the default ten-entry LRU otherwise exceed the Metal working-set limit on a
+24 GB machine. Explicit `--decode-concurrency`, `--prompt-concurrency`, and
+`--prompt-cache-bytes` values override those conservative defaults. mlx-lm
+routes per-request seeded server
+generation through its sequential path, so those requests deliberately fall
+back to ordinary AR even when the server was started with `--mtp`.
+
+The MTP path follows the checkpoint's native alignment
+`(target_hidden_t, embedding(token_t+1)) -> token_t+2` and shares the target
+embedding and LM head. The Metal default is:
+`topk=3`, `depth=3`, three selected tree nodes and M=4 target verification.
+It builds a 21-candidate lattice, then selects the best ancestor-closed three
+nodes. Tree full attention
+uses an ancestor mask and depth-aware RoPE; GDN recurrent and convolution state
+branch from each node's parent. Gate/up and K/V coded projections use
+multi-shard Metal dispatches at M>1; traced GDN verification likewise shares
+one dispatch for its qkv/z projections, and builds all parent-relative
+depthwise-convolution windows in one Metal pass. Tree proposal scoring uses a
+two-stage Metal reduction that computes top-k logits and logsumexp together;
+unsupported shapes and devices fall back to the regular MLX operators.
+
+Proposal branches share the committed MTP KV prefix: only the two live
+three-node levels are appended temporarily and then trimmed, rather than
+materializing `batch * topk` copies of a long prefix. For fresh continuous-batch
+requests, the shifted MTP cache is built from hidden states produced by the
+original target prefill. A target-only prefix-cache hit falls back to one replay
+because that public cache format does not contain historical hidden states.
+
+The same fixed-tree path is used by the Python API, CLI, and continuous-batching
+server. Every request accepts and commits its own path:
+attention histories are right-aligned in the rectangular MLX batch cache,
+while GDN/conv state is selected from that request's final accepted node. A
+low-acceptance request no longer shortens the whole batch.
+
+### Qwen3.8 MTP performance
+
+Batch-1 end-to-end decode on a 24 GB, 16-core-GPU M5 Pro with
+`Qwen3.8-27B-Escha-W2`, macOS 26.6.2, MLX 0.32.0 and mlx-lm 0.31.3. This is a
+256-output-token greedy smoke test after warm-up.
+
+| decode path | latency / output token | output throughput | speedup |
+|---|---:|---:|---:|
+| autoregressive (MTP off) | 59.759 ms | 16.73 tok/s | 1.000x |
+| fixed-tree M4 (MTP on) | 43.880 ms | 22.79 tok/s | **1.362x** |
+
+The MTP run emitted 2.931 tokens per target verification round on average.
+Greedy outputs can diverge at near-tied logits, so this measurement is a
+performance regression test rather than a bit-identity assertion.
+
+Small-row coded-projection experiments which did not clear the whole-target
+retention gate are recorded in
+[docs/MTP_CODED_PROJECTION_EXPERIMENTS.md](docs/MTP_CODED_PROJECTION_EXPERIMENTS.md).
 
 ## Benchmarks
 
@@ -226,7 +302,10 @@ campaign — including every negative result, so you don't repeat them:
 | `escha_mlx/msl.py` | the Metal kernels (`mx.fast.metal_kernel`): decode, GEMV ×2, row-blocked GEMM, fused transform |
 | `escha_mlx/quant.py` / `moe.py` / `dense.py` / `loader.py` | int8→Q8 repack · expert toolkit · dense-linear toolkit · streaming loader — all architecture-agnostic |
 | `escha_mlx/models/` | one plugin per architecture (`qwen3_5_moe`, `qwen3_5`): skeleton, tensor map, router, quirks |
-| `escha_mlx/gdn_cache.py` | recurrent-state cache (fp16 state) + allocation-free first-state Metal kernel |
+| `escha_mlx/gdn_cache.py` | recurrent-state cache + allocation-free init and MTP state-trace Metal kernels |
+| `escha_mlx/mtp.py` | Qwen3.8 native MTP head, 15-tensor loader, speculative verify loop |
+| `escha_mlx/mtp_topk.py` | fused Metal top-k/logsumexp reduction for MTP tree proposals |
+| `escha_mlx/mtp_batch.py` | native-MTP continuous batching with per-request tree-path commit |
 | `escha_mlx/{generate,server}.py` | CLI / OpenAI-compatible server |
 | `tests/` + `tests/data/` | golden-gated suite + the committed reference vectors |
 | `bench/` | gates, roofline, serving grid, head-to-head; results per machine under `bench/results/` |

--- a/bench/mtp.py
+++ b/bench/mtp.py
@@ -1,0 +1,311 @@
+"""Reproduce Qwen3.8 native-MTP one-shot and continuous-batch benchmarks.
+
+The public result uses two separate measurements:
+
+* ``one-shot``: one loaded model, both paths warmed, then AR/MTP/MTP/AR.
+  Timing includes prefill and 256 generated tokens.
+* ``continuous``: decode-only after prefill at each batch shape.  Every ABBA
+  arm runs in a fresh subprocess so MLX allocator or cache state from one path
+  cannot affect the other path.
+
+Examples::
+
+    python bench/mtp.py --model ~/models/Qwen3.8-27B-Escha-W2 \
+        --mode one-shot --out /tmp/mtp-one-shot.json
+    python bench/mtp.py --model ~/models/Qwen3.8-27B-Escha-W2 \
+        --mode continuous --batches 1,2,4,8 --out /tmp/mtp-batch.json
+"""
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import mlx.core as mx
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from escha_mlx.benchmark_metadata import (  # noqa: E402
+    annotate_report,
+    benchmark_metadata,
+    model_display_name,
+)
+
+
+def _digest_tokens(tokens: list[int]) -> str:
+    payload = b"".join(int(token).to_bytes(4, "little") for token in tokens)
+    return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def _one_shot(args: argparse.Namespace) -> dict:
+    from mlx_lm.generate import generate_step
+
+    from escha_mlx.loader import load
+    from escha_mlx.mtp import mtp_generate_step
+
+    mx.set_memory_limit(19_000_000_000)
+    model, tokenizer = load(args.model, load_mtp=True)
+    text = tokenizer.apply_chat_template(
+        [{"role": "user", "content": args.prompt}],
+        tokenize=False,
+        add_generation_prompt=True,
+        enable_thinking=False,
+    )
+    prompt = mx.array(tokenizer.encode(text), dtype=mx.uint32)
+
+    def run_ar(max_tokens: int) -> tuple[float, list[int], float | None]:
+        started = time.perf_counter()
+        tokens = [
+            int(token)
+            for token, _ in generate_step(prompt, model, max_tokens=max_tokens)
+        ]
+        mx.synchronize()
+        return time.perf_counter() - started, tokens, None
+
+    def run_mtp(max_tokens: int) -> tuple[float, list[int], float | None]:
+        started = time.perf_counter()
+        output = list(mtp_generate_step(prompt, model, max_tokens=max_tokens))
+        mx.synchronize()
+        tokens = [int(token) for token, _, _ in output]
+        target_rounds = sum(not accepted for _, _, accepted in output)
+        mean_emit = len(tokens) / target_rounds if target_rounds else None
+        return time.perf_counter() - started, tokens, mean_emit
+
+    run_ar(args.warmup_tokens)
+    run_mtp(args.warmup_tokens)
+    mx.clear_cache()
+
+    results: dict[str, list[dict]] = {"ar": [], "mtp": []}
+    order = (("ar", run_ar), ("mtp", run_mtp),
+             ("mtp", run_mtp), ("ar", run_ar))
+    for name, runner in order:
+        elapsed, tokens, mean_emit = runner(args.output_tokens)
+        row = {
+            "elapsed_s": elapsed,
+            "output_tokens": len(tokens),
+            "reached_max_tokens": len(tokens) == args.output_tokens,
+            "ms_per_token": 1000 * elapsed / len(tokens),
+            "tokens_per_s": len(tokens) / elapsed,
+            "mean_emit": mean_emit,
+            "digest": _digest_tokens(tokens),
+        }
+        results[name].append(row)
+        mx.clear_cache()
+
+    if not all(r["reached_max_tokens"] for rows in results.values() for r in rows):
+        raise RuntimeError("one-shot generation stopped before --output-tokens")
+
+    medians = {
+        name: {
+            "ms_per_token": statistics.median(r["ms_per_token"] for r in rows),
+            "tokens_per_s": statistics.median(r["tokens_per_s"] for r in rows),
+            "mean_emit": rows[0]["mean_emit"],
+        }
+        for name, rows in results.items()
+    }
+    return {
+        "model": model_display_name(args.model),
+        "workload": {
+            "prompt": args.prompt,
+            "prompt_tokens": int(prompt.size),
+            "output_tokens": args.output_tokens,
+            "warmup_tokens": args.warmup_tokens,
+            "sampling": "greedy",
+            "order": "ABBA",
+            "timing": "end-to-end including prefill",
+        },
+        "runs": results,
+        "medians": medians,
+        "median_speedup": (
+            medians["ar"]["ms_per_token"] / medians["mtp"]["ms_per_token"]
+        ),
+    }
+
+
+def _batch_arm(args: argparse.Namespace) -> dict:
+    from mlx_lm.generate import BatchGenerator
+
+    from escha_mlx.loader import load
+    from escha_mlx.mtp_batch import MTPBatchGenerator
+
+    model, tokenizer = load(args.model, load_mtp=True)
+    seed = tokenizer.encode(
+        "Analyze the performance of speculative decoding on Apple silicon. " * 12
+    )[:args.isl]
+    if len(seed) != args.isl:
+        raise ValueError(f"could construct only {len(seed)} of {args.isl} prompt tokens")
+    prompts = [seed[:-1] + [seed[-1] - (i % 7)] for i in range(args.batch)]
+    generator_type = MTPBatchGenerator if args.path == "mtp" else BatchGenerator
+
+    def run(max_tokens: int) -> dict:
+        generator = generator_type(
+            model,
+            max_tokens=max_tokens,
+            stop_tokens=None,
+            prefill_batch_size=args.batch,
+            completion_batch_size=args.batch,
+            prefill_step_size=args.prefill_step_size,
+        )
+        uids = generator.insert(prompts)
+        live = set(uids)
+        outputs = {uid: [] for uid in uids}
+        finish_reasons: dict[int, str] = {}
+        try:
+            while len(generator._generation_batch) == 0:
+                generator.next()
+            start_steps = generator._steps_counter
+            mx.reset_peak_memory()
+            started = time.perf_counter()
+            while live:
+                _, responses = generator.next()
+                for response in responses:
+                    outputs[response.uid].append(int(response.token))
+                    if response.finish_reason is not None:
+                        live.discard(response.uid)
+                        finish_reasons[response.uid] = response.finish_reason
+            mx.synchronize()
+            elapsed = time.perf_counter() - started
+            steps = generator._steps_counter - start_steps
+        finally:
+            generator.close()
+
+        output_lists = [outputs[uid] for uid in uids]
+        lengths = [len(tokens) for tokens in output_lists]
+        output_total = sum(lengths)
+        return {
+            "path": args.path,
+            "batch": args.batch,
+            "seconds": elapsed,
+            "output_tokens_per_request": lengths,
+            "finish_reasons": [finish_reasons.get(uid) for uid in uids],
+            "reached_max_tokens": all(n == max_tokens for n in lengths),
+            "output_tps": output_total / elapsed,
+            "steps": steps,
+            "emission_per_request_round": output_total / (steps * args.batch),
+            "peak_gb": mx.get_peak_memory() / 1e9,
+            "digest": hashlib.sha256(repr(output_lists).encode()).hexdigest(),
+        }
+
+    run(args.warmup_tokens)
+    mx.clear_cache()
+    result = run(args.output_tokens)
+    if not result["reached_max_tokens"]:
+        raise RuntimeError("continuous-batch generation stopped before --output-tokens")
+    del model, tokenizer
+    gc.collect()
+    mx.clear_cache()
+    return result
+
+
+def _continuous(args: argparse.Namespace) -> dict:
+    rows = []
+    script = str(Path(__file__).resolve())
+    for batch in (int(value) for value in args.batches.split(",")):
+        for path in ("ar", "mtp", "mtp", "ar"):
+            command = [
+                sys.executable, script,
+                "--mode", "_batch-arm",
+                "--model", args.model,
+                "--path", path,
+                "--batch", str(batch),
+                "--isl", str(args.isl),
+                "--output-tokens", str(args.output_tokens),
+                "--warmup-tokens", str(args.warmup_tokens),
+                "--prefill-step-size", str(args.prefill_step_size),
+            ]
+            print(f"running batch={batch} path={path}", file=sys.stderr, flush=True)
+            result = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=args.arm_timeout,
+            )
+            if result.returncode != 0:
+                detail = result.stderr.strip().splitlines()[-1:] or ["no stderr"]
+                raise RuntimeError(
+                    f"batch={batch} path={path} failed: {detail[0]}"
+                )
+            rows.append(json.loads(result.stdout))
+
+    summary = []
+    for batch in (int(value) for value in args.batches.split(",")):
+        ar = [r for r in rows if r["batch"] == batch and r["path"] == "ar"]
+        mtp = [r for r in rows if r["batch"] == batch and r["path"] == "mtp"]
+        ar_mean = statistics.mean(r["output_tps"] for r in ar)
+        mtp_mean = statistics.mean(r["output_tps"] for r in mtp)
+        summary.append({
+            "batch": batch,
+            "ar_tps_mean": ar_mean,
+            "mtp_tps_mean": mtp_mean,
+            "speedup": mtp_mean / ar_mean,
+            "mtp_emission_mean": statistics.mean(
+                r["emission_per_request_round"] for r in mtp
+            ),
+            "ar_peak_gb_max": max(r["peak_gb"] for r in ar),
+            "mtp_peak_gb_max": max(r["peak_gb"] for r in mtp),
+            "ar_samples": [r["output_tps"] for r in ar],
+            "mtp_samples": [r["output_tps"] for r in mtp],
+        })
+    return {
+        "model": model_display_name(args.model),
+        "workload": {
+            "isl": args.isl,
+            "osl": args.output_tokens,
+            "warmup_tokens": args.warmup_tokens,
+            "order": "ABBA, fresh process per arm",
+            "stop_tokens": None,
+        },
+        "rows": rows,
+        "summary": summary,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", required=True)
+    parser.add_argument(
+        "--mode", choices=("one-shot", "continuous", "_batch-arm"),
+        default="one-shot",
+    )
+    parser.add_argument("--out")
+    parser.add_argument("--prompt", default="Explain speculative decoding in one paragraph.")
+    parser.add_argument("--batches", default="1,2,4,8")
+    parser.add_argument("--path", choices=("ar", "mtp"))
+    parser.add_argument("--batch", type=int)
+    parser.add_argument("--isl", type=int, default=128)
+    parser.add_argument("--output-tokens", type=int)
+    parser.add_argument("--warmup-tokens", type=int)
+    parser.add_argument("--prefill-step-size", type=int, default=256)
+    parser.add_argument("--arm-timeout", type=float, default=600.0)
+    args = parser.parse_args()
+
+    if args.output_tokens is None:
+        args.output_tokens = 96 if args.mode in ("continuous", "_batch-arm") else 256
+    if args.warmup_tokens is None:
+        args.warmup_tokens = 16 if args.mode in ("continuous", "_batch-arm") else 8
+
+    if args.mode == "_batch-arm":
+        if args.path is None or args.batch is None:
+            parser.error("_batch-arm requires --path and --batch")
+        print(json.dumps(_batch_arm(args)))
+        return
+
+    report = _one_shot(args) if args.mode == "one-shot" else _continuous(args)
+    report = annotate_report(report, benchmark_metadata(args.model))
+    payload = json.dumps(report, indent=2) + "\n"
+    if args.out:
+        Path(args.out).write_text(payload)
+        print(f"wrote {args.out}", file=sys.stderr)
+    else:
+        print(payload, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/results/m5-pro-24gb/dense27b_mtp_20260907.json
+++ b/bench/results/m5-pro-24gb/dense27b_mtp_20260907.json
@@ -1,0 +1,578 @@
+{
+  "measurement_date": "2026-09-07",
+  "runtime_revision": "b30bb9b83113a4d391aeb676fc3ebf1f3cba0ad4",
+  "model": "EschaLabs/Qwen3.8-27B-Escha-W2",
+  "machine": {
+    "device": "Apple M5 Pro, 16-core GPU",
+    "ram_bytes": 25769803776,
+    "macos": "26.6.2",
+    "mlx": "0.32.0",
+    "mlx_lm": "0.31.3",
+    "max_recommended_working_set_bytes": 19069665280
+  },
+  "reproduce_with": {
+    "one_shot": "python bench/mtp.py --model \"$MODEL\" --mode one-shot --out /tmp/mtp-one-shot.json",
+    "continuous_batch": "python bench/mtp.py --model \"$MODEL\" --mode continuous --batches 1,2,4,8 --out /tmp/mtp-batch.json",
+    "server": "python -m escha_mlx.server --model \"$MODEL\" --mtp --port 18102 --prefill-step-size 256 --decode-concurrency 8 --prompt-concurrency 2",
+    "server_client": "python bench/isl_osl_grid.py --model \"$MODEL\" --url http://127.0.0.1:18102/v1/chat/completions --grid 128:96 --concurrency 8 --requests-per-point 16 --timeout 600"
+  },
+  "one_shot_abba": {
+    "workload": {
+      "prompt": "chat template: Explain speculative decoding in one paragraph.",
+      "prompt_tokens": 20,
+      "output_tokens": 256,
+      "sampling": "greedy",
+      "order": "ABBA",
+      "timing": "end-to-end including prefill"
+    },
+    "runs": {
+      "ar": [
+        {
+          "elapsed_s": 15.371962083008839,
+          "ms_per_token": 60.04672688675328,
+          "tokens_per_s": 16.653697076378144,
+          "mean_emit": null,
+          "digest": "8ddd7b0b9c542d72",
+          "output_tokens": 256,
+          "reached_max_tokens": true
+        },
+        {
+          "elapsed_s": 15.413509584002895,
+          "ms_per_token": 60.20902181251131,
+          "tokens_per_s": 16.60880661894763,
+          "mean_emit": null,
+          "digest": "8ddd7b0b9c542d72",
+          "output_tokens": 256,
+          "reached_max_tokens": true
+        }
+      ],
+      "mtp": [
+        {
+          "elapsed_s": 11.912896291993093,
+          "ms_per_token": 46.53475114059802,
+          "tokens_per_s": 21.489316596507514,
+          "mean_emit": 2.8444444444444446,
+          "digest": "8ddd7b0b9c542d72",
+          "output_tokens": 256,
+          "reached_max_tokens": true
+        },
+        {
+          "elapsed_s": 11.945475666987477,
+          "ms_per_token": 46.66201432416983,
+          "tokens_per_s": 21.430707921282846,
+          "mean_emit": 2.8444444444444446,
+          "digest": "8ddd7b0b9c542d72",
+          "output_tokens": 256,
+          "reached_max_tokens": true
+        }
+      ]
+    },
+    "median_speedup": 1.290342514566411,
+    "medians": {
+      "ar": {
+        "ms_per_token": 60.12787434963229,
+        "tokens_per_s": 16.631251847662888,
+        "mean_emit": null
+      },
+      "mtp": {
+        "ms_per_token": 46.598382732383925,
+        "tokens_per_s": 21.46001225889518,
+        "mean_emit": 2.8444444444444446
+      }
+    }
+  },
+  "continuous_batch_abba": {
+    "model": "EschaLabs/Qwen3.8-27B-Escha-W2",
+    "runtime_revision": "b30bb9b83113a4d391aeb676fc3ebf1f3cba0ad4",
+    "workload": {
+      "isl": 128,
+      "osl": 96,
+      "order": "ABBA, fresh process per arm",
+      "warmup_tokens": 16
+    },
+    "rows": [
+      {
+        "path": "ar",
+        "batch": 1,
+        "seconds": 5.630183582979953,
+        "output_tps": 17.050953771775408,
+        "steps": 96,
+        "emission_per_request_round": 1.0,
+        "peak_gb": 11.284608355,
+        "digest": "f879acd5dc82891ab9247edf56626838b56d6f6cdc7ca61ad6a44295b8c2aa13",
+        "output_tokens_per_request": [
+          96
+        ],
+        "finish_reasons": [
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "mtp",
+        "batch": 1,
+        "seconds": 4.9563340000167955,
+        "output_tps": 19.36915470177649,
+        "steps": 36,
+        "emission_per_request_round": 2.6666666666666665,
+        "peak_gb": 11.602885557,
+        "digest": "f879acd5dc82891ab9247edf56626838b56d6f6cdc7ca61ad6a44295b8c2aa13",
+        "output_tokens_per_request": [
+          96
+        ],
+        "finish_reasons": [
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "mtp",
+        "batch": 1,
+        "seconds": 4.958327250002185,
+        "output_tps": 19.361368292090383,
+        "steps": 36,
+        "emission_per_request_round": 2.6666666666666665,
+        "peak_gb": 11.602803637,
+        "digest": "f879acd5dc82891ab9247edf56626838b56d6f6cdc7ca61ad6a44295b8c2aa13",
+        "output_tokens_per_request": [
+          96
+        ],
+        "finish_reasons": [
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "ar",
+        "batch": 1,
+        "seconds": 5.631840999994893,
+        "output_tps": 17.045935778387044,
+        "steps": 96,
+        "emission_per_request_round": 1.0,
+        "peak_gb": 11.284620641,
+        "digest": "f879acd5dc82891ab9247edf56626838b56d6f6cdc7ca61ad6a44295b8c2aa13",
+        "output_tokens_per_request": [
+          96
+        ],
+        "finish_reasons": [
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "ar",
+        "batch": 2,
+        "seconds": 7.663272624980891,
+        "output_tps": 25.05456994628046,
+        "steps": 96,
+        "emission_per_request_round": 1.0,
+        "peak_gb": 11.416147958,
+        "digest": "dc666d7b06bc7ddd73e0227572522e630a6e6b7e57a9818376ee2d13d8aaebc5",
+        "output_tokens_per_request": [
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "mtp",
+        "batch": 2,
+        "seconds": 7.207485958002508,
+        "output_tps": 26.638969693284167,
+        "steps": 39,
+        "emission_per_request_round": 2.4615384615384617,
+        "peak_gb": 12.247174194,
+        "digest": "dc666d7b06bc7ddd73e0227572522e630a6e6b7e57a9818376ee2d13d8aaebc5",
+        "output_tokens_per_request": [
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "mtp",
+        "batch": 2,
+        "seconds": 7.288611291995039,
+        "output_tps": 26.342466665888796,
+        "steps": 39,
+        "emission_per_request_round": 2.4615384615384617,
+        "peak_gb": 12.247181362,
+        "digest": "dc666d7b06bc7ddd73e0227572522e630a6e6b7e57a9818376ee2d13d8aaebc5",
+        "output_tokens_per_request": [
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "ar",
+        "batch": 2,
+        "seconds": 7.514031749975402,
+        "output_tps": 25.552194399581627,
+        "steps": 96,
+        "emission_per_request_round": 1.0,
+        "peak_gb": 11.41618289,
+        "digest": "dc666d7b06bc7ddd73e0227572522e630a6e6b7e57a9818376ee2d13d8aaebc5",
+        "output_tokens_per_request": [
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "ar",
+        "batch": 4,
+        "seconds": 8.905451250000624,
+        "output_tps": 43.11965662604386,
+        "steps": 96,
+        "emission_per_request_round": 1.0,
+        "peak_gb": 11.681535224,
+        "digest": "570a552a54a6bc70de7f035deb687084c2f348f1e269ca034f208f77ba95da9f",
+        "output_tokens_per_request": [
+          96,
+          96,
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length",
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "mtp",
+        "batch": 4,
+        "seconds": 11.451820209011203,
+        "output_tps": 33.531787348341204,
+        "steps": 39,
+        "emission_per_request_round": 2.4615384615384617,
+        "peak_gb": 13.679398554,
+        "digest": "d38d36fbd48439d4c7dc530b995cfd572be7bef5b9adba4e60f9887125c02d32",
+        "output_tokens_per_request": [
+          96,
+          96,
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length",
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "mtp",
+        "batch": 4,
+        "seconds": 11.448350207996555,
+        "output_tps": 33.54195085085534,
+        "steps": 39,
+        "emission_per_request_round": 2.4615384615384617,
+        "peak_gb": 13.680217978,
+        "digest": "d38d36fbd48439d4c7dc530b995cfd572be7bef5b9adba4e60f9887125c02d32",
+        "output_tokens_per_request": [
+          96,
+          96,
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length",
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "ar",
+        "batch": 4,
+        "seconds": 8.897825374995591,
+        "output_tps": 43.15661229755144,
+        "steps": 96,
+        "emission_per_request_round": 1.0,
+        "peak_gb": 11.68153932,
+        "digest": "570a552a54a6bc70de7f035deb687084c2f348f1e269ca034f208f77ba95da9f",
+        "output_tokens_per_request": [
+          96,
+          96,
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length",
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "ar",
+        "batch": 8,
+        "seconds": 13.75867783400463,
+        "output_tps": 55.8193170350922,
+        "steps": 96,
+        "emission_per_request_round": 1.0,
+        "peak_gb": 12.185197326,
+        "digest": "8a0c4139c78cd08759229eb8546d21206ccc85d1cce6abe4c338dfcea78c705c",
+        "output_tokens_per_request": [
+          96,
+          96,
+          96,
+          96,
+          96,
+          96,
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "mtp",
+        "batch": 8,
+        "seconds": 18.455651333002606,
+        "output_tps": 41.613269894552765,
+        "steps": 39,
+        "emission_per_request_round": 2.4615384615384617,
+        "peak_gb": 16.513840641,
+        "digest": "1c08dd3a03b155f8465fda121deb32fbce898d39b653dbbf435d29d13797c308",
+        "output_tokens_per_request": [
+          96,
+          96,
+          96,
+          96,
+          96,
+          96,
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "mtp",
+        "batch": 8,
+        "seconds": 18.449767500016605,
+        "output_tps": 41.62654082222493,
+        "steps": 39,
+        "emission_per_request_round": 2.4615384615384617,
+        "peak_gb": 16.513840661,
+        "digest": "1c08dd3a03b155f8465fda121deb32fbce898d39b653dbbf435d29d13797c308",
+        "output_tokens_per_request": [
+          96,
+          96,
+          96,
+          96,
+          96,
+          96,
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      },
+      {
+        "path": "ar",
+        "batch": 8,
+        "seconds": 13.480012416985119,
+        "output_tps": 56.97324128813878,
+        "steps": 96,
+        "emission_per_request_round": 1.0,
+        "peak_gb": 12.18516454,
+        "digest": "8a0c4139c78cd08759229eb8546d21206ccc85d1cce6abe4c338dfcea78c705c",
+        "output_tokens_per_request": [
+          96,
+          96,
+          96,
+          96,
+          96,
+          96,
+          96,
+          96
+        ],
+        "finish_reasons": [
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length",
+          "length"
+        ],
+        "reached_max_tokens": true
+      }
+    ],
+    "summary": [
+      {
+        "batch": 1,
+        "ar_tps_mean": 17.048444775081226,
+        "mtp_tps_mean": 19.365261496933435,
+        "speedup": 1.1358960745345272,
+        "mtp_emission_mean": 2.6666666666666665,
+        "ar_peak_gb_max": 11.284620641,
+        "mtp_peak_gb_max": 11.602885557,
+        "ar_samples": [
+          17.050953771775408,
+          17.045935778387044
+        ],
+        "mtp_samples": [
+          19.36915470177649,
+          19.361368292090383
+        ],
+        "ar_drift_pct": -0.02942939999445171,
+        "mtp_drift_pct": -0.0402000490263732,
+        "same_ar_mtp_digest": true
+      },
+      {
+        "batch": 2,
+        "ar_tps_mean": 25.303382172931045,
+        "mtp_tps_mean": 26.49071817958648,
+        "speedup": 1.0469240040141994,
+        "mtp_emission_mean": 2.4615384615384617,
+        "ar_peak_gb_max": 11.41618289,
+        "mtp_peak_gb_max": 12.247181362,
+        "ar_samples": [
+          25.05456994628046,
+          25.552194399581627
+        ],
+        "mtp_samples": [
+          26.638969693284167,
+          26.342466665888796
+        ],
+        "ar_drift_pct": 1.9861624221374496,
+        "mtp_drift_pct": -1.113042399196551,
+        "same_ar_mtp_digest": true
+      },
+      {
+        "batch": 4,
+        "ar_tps_mean": 43.13813446179765,
+        "mtp_tps_mean": 33.53686909959828,
+        "speedup": 0.7774297502201427,
+        "mtp_emission_mean": 2.4615384615384617,
+        "ar_peak_gb_max": 11.68153932,
+        "mtp_peak_gb_max": 13.680217978,
+        "ar_samples": [
+          43.11965662604386,
+          43.15661229755144
+        ],
+        "mtp_samples": [
+          33.531787348341204,
+          33.54195085085534
+        ],
+        "ar_drift_pct": 0.08570492995358947,
+        "mtp_drift_pct": 0.03031005299107825,
+        "same_ar_mtp_digest": false
+      },
+      {
+        "batch": 8,
+        "ar_tps_mean": 56.39627916161549,
+        "mtp_tps_mean": 41.61990535838885,
+        "speedup": 0.7379902712928665,
+        "mtp_emission_mean": 2.4615384615384617,
+        "ar_peak_gb_max": 12.185197326,
+        "mtp_peak_gb_max": 16.513840661,
+        "ar_samples": [
+          55.8193170350922,
+          56.97324128813878
+        ],
+        "mtp_samples": [
+          41.613269894552765,
+          41.62654082222493
+        ],
+        "ar_drift_pct": 2.0672489638688063,
+        "mtp_drift_pct": 0.03189109557071301,
+        "same_ar_mtp_digest": false
+      }
+    ]
+  },
+  "server_stability_c8": {
+    "escha_mlx_git_revision": "b30bb9b83113a4d391aeb676fc3ebf1f3cba0ad4",
+    "model_hf_revision": null,
+    "results": [
+      {
+        "n_ok": 16,
+        "n_err": 0,
+        "errors": [],
+        "wall_s": 89.83,
+        "ttft_p50": 17.269,
+        "ttft_p99": 28.455,
+        "tpot_ms_p50": 294.86,
+        "per_user_tps": 2.32,
+        "aggregate_out_tps": 17.1,
+        "total_tps": 42.08,
+        "out_tok_mean": 96.0,
+        "osl_target": 96,
+        "osl_hit_rate": 1.0,
+        "cached_tok_mean": 0.0,
+        "isl": 128,
+        "osl": 96,
+        "concurrency": 8,
+        "n_requests": 16
+      }
+    ],
+    "launch": {
+      "decode_concurrency": 8,
+      "prompt_concurrency": 2,
+      "prompt_cache_bytes": 512000000,
+      "prompt_cache_budget_source": "MTP default"
+    },
+    "observed_prompt_cache_peak_gb": 0.44,
+    "log_errors": 0
+  },
+  "tests": {
+    "command": "ESCHA_MODEL=<Qwen3.6> ESCHA_DENSE_MODEL=<Qwen3.8> ESCHA_MLX_SLOW_TESTS=1 pytest -q -rs",
+    "passed": 379,
+    "skipped": 0,
+    "duration_s": 26.53
+  }
+}

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -121,6 +121,14 @@ escha-mlx-server --model ./escha-w2 --port 8080 \
 materialises a much larger activation transient and pushes peak memory past the
 cap on long prompts.
 
+When `--mtp` is enabled, escha-mlx defaults both prompt and decode concurrency
+to 2 and applies a 512 MB prompt-cache byte budget. Tree verification is faster
+than ordinary AR at B=1/2 but slower from B=4 onward, and B=8 verification peaks
+near the 24 GB machine's Metal working-set limit; retaining mlx-lm's default ten
+Qwen3.8 cache entries adds about 0.9 GB and can cross that limit. Explicit
+`--decode-concurrency`, `--prompt-concurrency`, and `--prompt-cache-bytes`
+values override these MTP defaults.
+
 ---
 
 ## Generating from a reasoning model
@@ -230,6 +238,7 @@ bit-identical or documents where it is not.
 | kernel | `ESCHA_MLX_SORTX=1` | Pre-sort inputs into expert order. Measured neutral or slower on a 10-core M4. |
 | kernel | `ESCHA_MLX_PREFETCH=1` | Prefetch code tiles into registers. Measured neutral or slower on a 10-core M4. |
 | kernel | `ESCHA_MLX_DENSE=fp16` | Use fp16 dense weights instead of the Q8 repack. +~1.9 GB resident; bit-identical weight values. |
+| kernel | `ESCHA_MLX_Q8_HEAD=0` | Disable the default small-row Metal vocabulary head and use MLX QMM. The specialized path covers 1–8 flattened rows; larger batches already fall back automatically. |
 | kernel | `ESCHA_MLX_LUT=1` | Use table-based codec decode instead of multiply-hash. Bit-exact fallback for future Metal compiler changes. |
 | kernel | `ESCHA_MLX_MOE=ops` | Use the NumPy expert path. Very slow; a correctness oracle, not for serving. |
 | kernel | `ESCHA_MLX_LINEAR=ops` | Use the NumPy path for coded linears of a **dense** model. Very slow, and materializes decoded weights in f32; use only as a correctness oracle for a truncated load or single layer. |

--- a/docs/MTP_CODED_PROJECTION_EXPERIMENTS.md
+++ b/docs/MTP_CODED_PROJECTION_EXPERIMENTS.md
@@ -1,0 +1,175 @@
+# MTP coded-projection experiments
+
+This log records the small-row coded-linear optimizations tried for Qwen3.8
+native MTP and then removed because they did not improve the complete target
+verification enough to justify production complexity.  It exists so the same
+ideas are not reintroduced from convincing-looking single-kernel results.
+
+## Measurement contract
+
+- Date: 2026-09-05
+- Runtime base: `84dd1860bf5ce89e7f8fd6a5a31faa98099807ac`
+- Model: `/Users/tu/Dev/repos/models/Qwen3.8-27B-Escha-W2`
+- Machine: Apple M5 Pro, 16-core GPU, 24 GB unified memory
+- Software: macOS 26.6.2, MLX 0.32.0, mlx-lm 0.31.3
+- Target shapes: fixed tree M4 and the prospective/batched M8 shape
+- Timing: one model load per experiment, both arms compiled and warmed, ABBA
+  interleaving, `mx.eval` plus `mx.synchronize` for every sample
+
+An implementation must improve complete M4/M8 target verification by at least
+3%, exceed twice the measured drift, and preserve M1.  A final candidate must
+also improve a 256-token, multi-prompt end-to-end run by at least 2%.  A
+reassociated kernel must be deterministic and tolerance-gated; a kernel which
+keeps operation order must be bit-exact.
+
+Absolute times drift with temperature, so decisions use the paired ratios from
+one process rather than comparing numbers from separate runs.
+
+## Results
+
+| Experiment | Scope | Reference | Candidate | Speedup | Decision |
+|---|---|---:|---:|---:|---|
+| Parallel output WHT across rows | full target M4 | 100.771 ms | 100.622 ms | 1.001x | remove |
+| Parallel output WHT across rows | full target M8 | 146.928 ms | 147.370 ms | 0.997x | remove |
+| Native R8 matrix core + fused output WHT | full target M8 | 146.594 ms | 145.283 ms | 1.009x | remove |
+| Fused SwiGLU + down input WHT | one complete MLP, M4 | 1.036 ms | 1.040 ms | 0.996x | remove |
+| Fused SwiGLU + down input WHT | one complete MLP, M8 | 1.509 ms | 1.499 ms | 1.006x | remove |
+| `down_proj` on-chip split-K=2 | eight layers, M4 | 2.283 ms | 2.264 ms | 1.009x | remove |
+| `down_proj` on-chip split-K=2 | eight layers, M8 | 3.344 ms | 3.234 ms | 1.034x | remove |
+| Code-stream prefetch PF2 | full target M8 | 146.839 ms | 145.137 ms | 1.012x | remove |
+| Code-stream prefetch PF4 | full target M8 | 147.047 ms | 148.380 ms | 0.991x | remove |
+| Code-stream prefetch PF8 | full target M8 | 146.748 ms | 267.678 ms | 0.548x | remove |
+| `mx.compile` fixed M4 target body | full target M4 | runs normally | cannot capture stateful body | n/a | reject |
+
+No experimental kernel, switch, allowlist, or alternate runtime path from this
+campaign remains in the code.
+
+After removing the candidates, an 11-sample profile measured 101.080 ms for
+the complete M4 target body plus vocabulary head (M1 72.462 ms, M8 146.992
+ms).  A final 256-token smoke test measured autoregressive decoding at 59.759
+ms/token and fixed-tree M4 at 43.880 ms/token, or 1.362x, with mean emission
+2.931 tokens per target round.  As documented for this checkpoint, the two
+greedy digests can diverge at near ties; this smoke test is a performance
+regression check rather than a bit-identity assertion.
+
+## What each result means
+
+### Native R8 simdgroup matrix
+
+The prototype used one native 8-row fragment, loaded A directly from device
+memory, partitioned decoded B storage by simdgroup, used simdgroup barriers,
+and fused output Hadamard/rout/f16 writeback.  Single-projection error versus
+the scalar kernel was at most 0.001953125 after f16 output.  It was sometimes
+slightly faster for K3 `up_proj`, but `down_proj` was neutral or slower; the
+complete target gained only 0.9%.
+
+M4 cannot use a native four-row matrix fragment.  It would still compute eight
+rows, so an M4 half-tile was not pursued after the exact M8 tile failed the
+whole-target gate.
+
+Target ABBA samples in milliseconds:
+
+```text
+scalar: 146.5995 147.9442 148.1532 146.3863 146.3147 146.1426
+        146.6900 146.4425 146.6915 147.5520 146.5887 146.1415
+R8:     146.0271 146.5791 145.0580 145.1033 145.8522 144.8204
+        145.3618 145.1500 145.2638 145.3015 145.3869 145.2020
+```
+
+### Output-WHT row parallelism
+
+The existing fused epilogue runs the seven H128 stages one row at a time.  The
+prototype processed all R rows concurrently, reducing full-threadgroup
+barriers from `14*R` to 14 while keeping every butterfly operation identical.
+Projection output was bit-exact.  Complete-target performance was unchanged at
+M4 and slightly worse at M8, proving those epilogue barriers are not the
+limiter.
+
+```text
+M4 serial:   100.9823 101.1422 101.0420 100.9549 100.8902 100.3438
+             100.6279 101.0714 100.6520 100.3253 100.6103 100.5978
+M4 parallel: 101.5909 100.6944 100.7268 100.5874 100.6846 100.3405
+             100.5218 100.8767 100.4645 100.2293 100.0357 100.6567
+M8 serial:   147.2411 146.9076 146.5590 146.6109 147.1075 146.9516
+             146.5423 146.9223 146.7439 147.8696 148.0703 146.9335
+M8 parallel: 147.3960 147.5506 146.9998 146.7429 146.8641 147.0288
+             146.9539 147.6056 147.7096 148.5661 147.8122 147.3440
+```
+
+### MLP fusion
+
+The low-risk fusion combined the FP16 SwiGLU result with `down_proj`'s input
+scale and H128 transform.  It measured the useful boundary of a larger
+gate/up/SwiGLU kernel while reusing the existing coded down GEMM.  It saved an
+intermediate tensor but did not reduce coded-stream reads or decoding, and was
+a wash at both row counts.  A same-threadgroup gate/up kernel would double
+accumulator pressure and still decode the same two streams, so it was stopped
+at this gate rather than adding a larger negative-risk kernel.
+
+The custom activation differed by at most 0.00390625 at final f16 MLP output;
+that numerical cost is not justified by a 0.4--0.6% timing change.
+
+### `down_proj` on-chip split-K
+
+The prototype used a 512-thread group with 16 simdgroups: eight output shards
+times two fixed K halves.  Both partials stayed in threadgroup memory, were
+reduced in a fixed order, and then used the existing output transform.  It
+created no global partial buffer and no reduction dispatch.  Results were
+deterministic; maximum f16 difference versus the sequential accumulator was
+0.001953125.
+
+Across eight different layer weights it gained 0.9% at M4 and 3.4% at M8.
+`down_proj` would need about 1.16x locally to move the full target by the 3%
+retention threshold, so the target integration was not warranted.
+
+### Code-stream prefetch and repacking
+
+PF2 kept two independent code-word pairs in flight and preserved accumulation
+order exactly.  It gained 3--7% on isolated M8 projections but only 1.2% on the
+complete target.  PF4 regressed slightly, while PF8 hit a register/occupancy
+cliff and made target verification 82% slower.
+
+```text
+PF1 vs PF2 target samples:
+PF1: 146.7773 146.5055 147.0867 148.6519 146.5348 146.6247
+     147.0617 146.8997 146.4813 148.1547 147.8389 146.7019
+PF2: 145.3805 145.1296 144.8250 144.8893 145.9391 145.1440
+     144.8702 144.6462 144.8525 146.0629 146.3814 145.7685
+```
+
+The checkpoint already stores each compressed tile contiguously as
+`[TK, TN, 8*K]`.  A same-size permutation cannot remove the overlapping
+bit-window decode.  Expanding 24.3 billion coded weights to f16 would require
+about 48.6 GB just for the coded body, versus the 19 GB runtime working-set
+budget.  Streaming an expanded projection per layer would add decode and
+allocation work every token.  Consequently there is no memory-feasible offline
+repack left to retain after the PF experiment.
+
+### Fixed-shape graph capture
+
+Wrapping `_target_tree_forward` in `mx.compile` failed with:
+
+```text
+RuntimeError: [eval] Attempting to eval an array without a primitive.
+If you are compiling a function, make sure all the inputs and outputs are captured.
+```
+
+This target body mutates heterogeneous KV, GDN, and convolution caches.  MLX
+compile requires a pure captured input/output graph; it is not CUDA graph-style
+command-buffer capture.  Rewriting every cache as explicit functional inputs
+would be a large alternative runtime, not a small optimization, and earlier
+in-model compile experiments also found no throughput gain and unacceptable
+logit drift.  The current runtime therefore keeps MLX lazy scheduling plus the
+already measured projection-pair dispatch fusion.
+
+## Revisit conditions
+
+These paths should be reconsidered only when one of their premises changes:
+
+- a Metal/MLX release exposes smaller matrix fragments or command-buffer graph
+  capture;
+- a wider Apple GPU makes the measured split-K or PF2 ratios materially larger;
+- the checkpoint ships a matrix-friendly compressed layout without increasing
+  its working set;
+- profiling identifies a specific stall counter rather than another inferred
+  kernel bottleneck.

--- a/docs/MTP_CODED_PROJECTION_EXPERIMENTS.md
+++ b/docs/MTP_CODED_PROJECTION_EXPERIMENTS.md
@@ -46,11 +46,16 @@ campaign remains in the code.
 
 After removing the candidates, an 11-sample profile measured 101.080 ms for
 the complete M4 target body plus vocabulary head (M1 72.462 ms, M8 146.992
-ms).  A final 256-token smoke test measured autoregressive decoding at 59.759
-ms/token and fixed-tree M4 at 43.880 ms/token, or 1.362x, with mean emission
-2.931 tokens per target round.  As documented for this checkpoint, the two
-greedy digests can diverge at near ties; this smoke test is a performance
-regression check rather than a bit-identity assertion.
+ms). The final post-fix measurement at revision `b30bb9b` used a warmed ABBA
+run with a 20-token chat prompt and 256 output tokens, including prefill. It
+measured autoregressive generation at 60.128 ms/token and fixed-tree M4 at
+46.598 ms/token, or 1.290x, with mean emission 2.844 tokens per target round;
+both arms had the same token digest. As documented for this checkpoint, greedy
+digests can still diverge at shape-dependent near ties, so this is a
+performance regression check rather than a general bit-identity assertion.
+Continuous-batch and C=8 server results from the same revision are recorded in
+`bench/results/m5-pro-24gb/dense27b_mtp_20260907.json`; `bench/mtp.py`
+reproduces the one-shot and local continuous-batch measurements.
 
 ## What each result means
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -638,6 +638,45 @@ Raw evidence: [machine and software](../bench/results/m5-pro-24gb/dense27b_machi
 [opening roofline](../bench/results/m5-pro-24gb/dense27b_roofline_20260831-180252_open.json), and
 [closing roofline](../bench/results/m5-pro-24gb/dense27b_roofline_20260831-180252_close.json).
 
+### Native MTP post-fix validation — 2026-09-07
+
+This is a separate session at runtime revision
+`b30bb9b83113a4d391aeb676fc3ebf1f3cba0ad4`, macOS 26.6.2, MLX 0.32.0 and
+mlx-lm 0.31.3. The local checkpoint did not retain an unambiguous Hub revision,
+so the report identifies it as `Qwen3.8-27B-Escha-W2` without inventing one.
+
+The one-shot comparison used a 20-token chat prompt, 256 greedy output tokens,
+warmed AR/MTP/MTP/AR ordering, and end-to-end timing including prefill. Every
+arm reached the 256-token limit and both paths produced the same token digest.
+
+| path | median ms/output token | median output tok/s | relative |
+|---|---:|---:|---:|
+| AR | 60.128 | 16.63 | 1.000x |
+| fixed-tree M4 MTP | 46.598 | 21.46 | **1.290x** |
+
+Continuous-batch rows exclude prefill. Each arm used a fresh process, a
+128-token prompt, a 16-token warmup and 96 measured output tokens per request;
+all requests finished by the length limit.
+
+| batch | AR output tok/s | MTP output tok/s | MTP / AR | MTP peak |
+|---:|---:|---:|---:|---:|
+| 1 | 17.05 | 19.37 | **1.136x** | 11.60 GB |
+| 2 | 25.30 | 26.49 | **1.047x** | 12.25 GB |
+| 4 | 43.14 | 33.54 | 0.777x | 13.68 GB |
+| 8 | 56.40 | 41.62 | 0.738x | 16.51 GB |
+
+The crossover supports the conservative MTP server default of concurrency 2.
+A separate stress run explicitly raised decode concurrency to 8: all 16
+ISL/OSL 128/96 requests completed, OSL hit rate was 1.00, aggregate output was
+17.10 tok/s, and the Prompt LRU peaked at 0.44 GB under its 512 MB budget. The
+full test suite with both real checkpoints and slow tests enabled completed as
+379 passed, 0 skipped.
+
+Raw samples, commands, completion evidence and Server metrics are in
+[`dense27b_mtp_20260907.json`](../bench/results/m5-pro-24gb/dense27b_mtp_20260907.json).
+Use [`bench/mtp.py`](../bench/mtp.py) to reproduce the one-shot and continuous
+measurements.
+
 ---
 
 ## Apple M4 base 24 GB — Qwen3.8-27B dense (W2)

--- a/escha_mlx/__init__.py
+++ b/escha_mlx/__init__.py
@@ -14,3 +14,8 @@ from __future__ import annotations
 __version__ = "0.1.0"  # keep in sync with pyproject.toml [project] version
 
 from .loader import is_escha_checkpoint, load, load_model  # noqa: F401
+from .mtp import load_mtp, mtp_generate_step  # noqa: F401
+from .mtp_batch import (  # noqa: F401
+    MTPBatchGenerator,
+    batch_generate as mtp_batch_generate,
+)

--- a/escha_mlx/dense.py
+++ b/escha_mlx/dense.py
@@ -34,7 +34,8 @@ hundreds. The per-row GEMV reads the whole coded stream per row — no batch
 amortization at all — so above a few rows the forward switches to the
 row-blocked kernel, which shares one decode across R rows and is bit-identical
 to the per-row path (``msl.dense_block_r`` picks R; ESCHA_MLX_DENSE_BLOCK_R
-pins it).
+pins it). For R<=8, including the tree MTP verifier, a dense-only variant
+reads the consecutive rows directly and removes the staging barriers.
 
 Paths:
   * fused (default on Metal)  — escha_mlx.msl kernels.
@@ -320,6 +321,14 @@ class EschaLinear(nn.Module):
                 # for rather than silently getting a different blocking.
                 return msl.dense_gemm_mat(xh, w.code, w.K, w.IC, w.OC)
             if r > 1:
+                # Small dense groups have arithmetic row addresses. Direct
+                # reads keep one code decode shared across the rows while
+                # avoiding the staged kernel's barrier chain; this is the hot
+                # M=4/8 speculative-verification shapes.
+                if r <= 8:
+                    return msl.dense_gemm_rows_direct(
+                        xh, w.code, w.K, w.IC, w.OC, r
+                    )
                 return msl.dense_gemm_rows(xh, w.code, w.K, w.IC, w.OC, r)
             return msl.dense_gemv(xh, w.code, w.K, w.IC, w.OC)
         # ops path: numpy decode + matmul (test/CPU only — slow, see module doc)
@@ -328,12 +337,104 @@ class EschaLinear(nn.Module):
     def __call__(self, x: mx.array) -> mx.array:
         shape = x.shape
         rows = x.reshape(-1, shape[-1])
-        y = self._output_rows(self._gemv(self._input_rows(rows)))
+        xh = self._input_rows(rows)
+        r = (
+            msl.dense_block_r(rows.shape[0], self._block_r_pin)
+            if self._mode == "fused"
+            else 1
+        )
+        if (
+            self._mode == "fused"
+            and self._fused_had
+            and rows.shape[0] > 1
+            and r <= 8
+        ):
+            y = msl.dense_gemm_rows_direct_out(
+                xh, self._w.code, self._w.rout, self.K,
+                self._w.IC, self._w.OC, r, RS,
+            )
+        else:
+            y = self._output_rows(self._gemv(xh))
         if self.bias is not None:
             # The forward contract rounds the transform output to f16 before the
             # correction is added; keep that rounding point and add in f32.
             y = (y.astype(mx.float32) + self.bias.astype(mx.float32)).astype(mx.float16)
         return y.reshape(*shape[:-1], self._w.OC).astype(x.dtype)
+
+
+def project_pair(first: EschaLinear, second: EschaLinear, x: mx.array):
+    """Evaluate two compatible coded projections with one GEMM dispatch.
+
+    The per-projection Hadamard scales remain distinct.  Only the coded GEMM
+    launch is shared, matching SGLang's multi-shard projection shape without
+    coupling the linear modules or changing their checkpoint representation.
+    M=1 keeps the tuned GEMV path; fusion is for verification/prefill batches.
+    """
+    shape = x.shape
+    rows = x.reshape(-1, shape[-1])
+    compatible = (
+        rows.shape[0] > 1
+        and first._mode == second._mode == "fused"
+        and first._w.IC == second._w.IC == rows.shape[-1]
+        and first._w.OC % 128 == second._w.OC % 128 == 0
+    )
+    if not compatible:
+        return first(x), second(x)
+
+    r0 = msl.dense_block_r(rows.shape[0], first._block_r_pin)
+    r1 = msl.dense_block_r(rows.shape[0], second._block_r_pin)
+    if r0 != r1:
+        return first(x), second(x)
+    if first._fused_had and second._fused_had and rows.dtype == mx.float16:
+        xh0, xh1 = msl.dense_scaled_had_pair(
+            rows, first._w.rin, second._w.rin, RS
+        )
+    else:
+        xh0, xh1 = first._input_rows(rows), second._input_rows(rows)
+    if first._fused_had and second._fused_had and r0 <= 8:
+        out0, out1 = msl.dense_gemm_pair_out(
+            xh0,
+            xh1,
+            first._w.code,
+            second._w.code,
+            first._w.rout,
+            second._w.rout,
+            first.K,
+            second.K,
+            first._w.IC,
+            first._w.OC,
+            second._w.OC,
+            r0,
+            RS,
+        )
+    else:
+        mid0, mid1 = msl.dense_gemm_pair(
+            xh0,
+            xh1,
+            first._w.code,
+            second._w.code,
+            first.K,
+            second.K,
+            first._w.IC,
+            first._w.OC,
+            second._w.OC,
+            r0,
+        )
+        if first._fused_had and second._fused_had:
+            out0, out1 = msl.dense_scaled_had_out_pair(
+                mid0, mid1, first._w.rout, second._w.rout, RS
+            )
+        else:
+            out0, out1 = first._output_rows(mid0), second._output_rows(mid1)
+
+    def finish(linear, value):
+        if linear.bias is not None:
+            value = (
+                value.astype(mx.float32) + linear.bias.astype(mx.float32)
+            ).astype(mx.float16)
+        return value.reshape(*shape[:-1], linear._w.OC).astype(x.dtype)
+
+    return finish(first, out0), finish(second, out1)
 
 
 def build(group: dict[str, np.ndarray]) -> EschaLinear:

--- a/escha_mlx/envs.py
+++ b/escha_mlx/envs.py
@@ -194,6 +194,15 @@ ESCHA_MLX_DENSE = EnvVar(
     value_help="one of q8 or fp16",
 )
 
+ESCHA_MLX_Q8_HEAD = EnvVar(
+    "ESCHA_MLX_Q8_HEAD",
+    EnvLayer.KERNEL,
+    _bool,
+    "Use the small-row Metal kernel for Q8 vocabulary projection.",
+    default=True,
+    value_help="a boolean (0/1, false/true, no/yes, or off/on)",
+)
+
 ESCHA_MLX_MOE = EnvVar(
     "ESCHA_MLX_MOE",
     EnvLayer.KERNEL,
@@ -352,6 +361,7 @@ _DECLARATIONS = (
     ESCHA_MLX_Q8_GROUP,
     ESCHA_MLX_BIAS,
     ESCHA_MLX_DENSE,
+    ESCHA_MLX_Q8_HEAD,
     ESCHA_MLX_MOE,
     ESCHA_MLX_FUSED_HAD,
     ESCHA_MLX_LUT,

--- a/escha_mlx/gdn_cache.py
+++ b/escha_mlx/gdn_cache.py
@@ -75,6 +75,7 @@ from __future__ import annotations
 import logging
 
 import mlx.core as mx
+import mlx.nn as nn
 from mlx_lm.models.cache import ArraysCache
 
 from . import envs
@@ -187,6 +188,268 @@ _ZERO_STATE_KERNEL = _make_zero_state_kernel()
 _ZERO_STATE_MASKED_KERNEL = _make_zero_state_kernel(has_mask=True)
 
 
+def _make_trace_kernel(has_mask: bool = False):
+    """GDN kernel which exposes the recurrent state after every token.
+
+    Normal generation still uses mlx-lm's final-state-only kernel.  The larger
+    output exists only inside an MTP target verification transaction.
+    """
+    if not mx.metal.is_available():
+        return None
+
+    mask_source = "mask[b_idx * T + t]" if has_mask else "true"
+    source = f"""
+        auto n = thread_position_in_grid.z;
+        auto b_idx = n / Hv;
+        auto hv_idx = n % Hv;
+        auto hk_idx = hv_idx / (Hv / Hk);
+        constexpr int n_per_t = Dk / 32;
+
+        auto q_ = q + b_idx * T * Hk * Dk + hk_idx * Dk;
+        auto k_ = k + b_idx * T * Hk * Dk + hk_idx * Dk;
+        auto v_ = v + b_idx * T * Hv * Dv + hv_idx * Dv;
+        y += b_idx * T * Hv * Dv + hv_idx * Dv;
+
+        auto dk_idx = thread_position_in_threadgroup.x;
+        auto dv_idx = thread_position_in_grid.y;
+        auto i_state = state_in + (n * Dv + dv_idx) * Dk;
+
+        float state[n_per_t];
+        for (int i = 0; i < n_per_t; ++i) {{
+          auto s_idx = n_per_t * dk_idx + i;
+          state[i] = static_cast<float>(i_state[s_idx]);
+        }}
+
+        auto g_ = g + b_idx * T * Hv;
+        auto beta_ = beta + b_idx * T * Hv;
+        for (int t = 0; t < T; ++t) {{
+          if ({mask_source}) {{
+            float kv_mem = 0.0f;
+            for (int i = 0; i < n_per_t; ++i) {{
+              auto s_idx = n_per_t * dk_idx + i;
+              state[i] = state[i] * g_[hv_idx];
+              kv_mem += state[i] * k_[s_idx];
+            }}
+            kv_mem = simd_sum(kv_mem);
+
+            auto delta = (v_[dv_idx] - kv_mem) * beta_[hv_idx];
+            float out = 0.0f;
+            for (int i = 0; i < n_per_t; ++i) {{
+              auto s_idx = n_per_t * dk_idx + i;
+              state[i] = state[i] + k_[s_idx] * delta;
+              out += state[i] * q_[s_idx];
+            }}
+            out = simd_sum(out);
+            if (thread_index_in_simdgroup == 0) {{
+              y[dv_idx] = static_cast<InT>(out);
+            }}
+          }} else {{
+            y[dv_idx] = static_cast<InT>(0);
+          }}
+
+          auto o_state = state_trace
+              + (((b_idx * T + t) * Hv + hv_idx) * Dv + dv_idx) * Dk;
+          for (int i = 0; i < n_per_t; ++i) {{
+            auto s_idx = n_per_t * dk_idx + i;
+            o_state[s_idx] = static_cast<StT>(state[i]);
+          }}
+
+          q_ += Hk * Dk;
+          k_ += Hk * Dk;
+          v_ += Hv * Dv;
+          y += Hv * Dv;
+          g_ += Hv;
+          beta_ += Hv;
+        }}
+    """
+    inputs = ["q", "k", "v", "g", "beta", "state_in", "T"]
+    if has_mask:
+        inputs.append("mask")
+    suffix = "_mask" if has_mask else ""
+    return mx.fast.metal_kernel(
+        name=f"escha_gated_delta_trace{suffix}",
+        input_names=inputs,
+        output_names=["y", "state_trace"],
+        source=source,
+    )
+
+
+_TRACE_KERNEL = _make_trace_kernel()
+_TRACE_MASKED_KERNEL = _make_trace_kernel(has_mask=True)
+
+
+def _make_tree_trace_kernel():
+    """GDN recurrence where every candidate starts from its tree parent."""
+    if not mx.metal.is_available():
+        return None
+
+    source = """
+        auto n = thread_position_in_grid.z;
+        auto b_idx = n / Hv;
+        auto hv_idx = n % Hv;
+        auto hk_idx = hv_idx / (Hv / Hk);
+        constexpr int n_per_t = Dk / 32;
+
+        auto q_ = q + b_idx * T * Hk * Dk + hk_idx * Dk;
+        auto k_ = k + b_idx * T * Hk * Dk + hk_idx * Dk;
+        auto v_ = v + b_idx * T * Hv * Dv + hv_idx * Dv;
+        y += b_idx * T * Hv * Dv + hv_idx * Dv;
+
+        auto dk_idx = thread_position_in_threadgroup.x;
+        auto dv_idx = thread_position_in_grid.y;
+        auto base_state = state_in + (n * Dv + dv_idx) * Dk;
+        auto g_ = g + b_idx * T * Hv;
+        auto beta_ = beta + b_idx * T * Hv;
+
+        for (int t = 0; t < T; ++t) {
+          int parent = parents[b_idx * T + t];
+          device const StT* parent_state = base_state;
+          if (parent >= 0) {
+            parent_state = state_trace
+                + (((b_idx * T + parent) * Hv + hv_idx) * Dv + dv_idx) * Dk;
+          }
+
+          float state[n_per_t];
+          float kv_mem = 0.0f;
+          for (int i = 0; i < n_per_t; ++i) {
+            auto s_idx = n_per_t * dk_idx + i;
+            state[i] = static_cast<float>(parent_state[s_idx]) * g_[hv_idx];
+            kv_mem += state[i] * k_[s_idx];
+          }
+          kv_mem = simd_sum(kv_mem);
+
+          auto delta = (v_[dv_idx] - kv_mem) * beta_[hv_idx];
+          float out = 0.0f;
+          auto o_state = state_trace
+              + (((b_idx * T + t) * Hv + hv_idx) * Dv + dv_idx) * Dk;
+          for (int i = 0; i < n_per_t; ++i) {
+            auto s_idx = n_per_t * dk_idx + i;
+            state[i] += k_[s_idx] * delta;
+            out += state[i] * q_[s_idx];
+            o_state[s_idx] = static_cast<StT>(state[i]);
+          }
+          out = simd_sum(out);
+          if (thread_index_in_simdgroup == 0)
+            y[dv_idx] = static_cast<InT>(out);
+
+          q_ += Hk * Dk;
+          k_ += Hk * Dk;
+          v_ += Hv * Dv;
+          y += Hv * Dv;
+          g_ += Hv;
+          beta_ += Hv;
+        }
+    """
+    return mx.fast.metal_kernel(
+        name="escha_gated_delta_tree_trace",
+        input_names=["q", "k", "v", "g", "beta", "state_in", "parents", "T"],
+        output_names=["y", "state_trace"],
+        source=source,
+    )
+
+
+_TREE_TRACE_KERNEL = _make_tree_trace_kernel()
+
+
+def _make_tree_conv_window_kernel():
+    """Build every parent-relative depthwise-convolution window in one pass."""
+    if not mx.metal.is_available():
+        return None
+
+    source = """
+        uint linear = thread_position_in_grid.x;
+        if (linear >= (uint)(B * C)) return;
+        uint b = linear / C;
+        uint c = linear - b * C;
+
+        // One thread owns one channel and walks topologically ordered nodes.
+        // Reading an earlier node's trace is therefore ordered without a
+        // cross-threadgroup barrier.
+        for (uint t = 0; t < T; ++t) {
+          int parent = parents[b * T + t];
+          ulong window_base = ((ulong)b * T + t) * KS * C + c;
+          ulong trace_base = ((ulong)b * T + t) * (KS - 1) * C + c;
+
+          for (uint k = 0; k < KS - 1; ++k) {
+            InT value;
+            if (parent < 0) {
+              value = conv_state[((ulong)b * (KS - 1) + k) * C + c];
+            } else {
+              value = conv_trace[
+                  ((ulong)b * T + (uint)parent) * (KS - 1) * C
+                  + (ulong)k * C + c];
+            }
+            windows[window_base + (ulong)k * C] = value;
+            if (k > 0)
+              conv_trace[trace_base + (ulong)(k - 1) * C] = value;
+          }
+
+          InT current = qkv[((ulong)b * T + t) * C + c];
+          windows[window_base + (ulong)(KS - 1) * C] = current;
+          conv_trace[trace_base + (ulong)(KS - 2) * C] = current;
+        }
+    """
+    return mx.fast.metal_kernel(
+        name="escha_gdn_tree_conv_windows",
+        input_names=["qkv", "conv_state", "parents"],
+        output_names=["conv_trace", "windows"],
+        source=source,
+    )
+
+
+_TREE_CONV_WINDOW_KERNEL = _make_tree_conv_window_kernel()
+
+
+def tree_conv_windows(qkv, conv_state, parents):
+    """Return parent-relative conv states and `[B*T, KS, C]` windows."""
+    B, T, C = qkv.shape
+    if parents.shape != (B, T):
+        raise ValueError(
+            f"tree conv parents must have shape {(B, T)}, got {parents.shape}"
+        )
+    if conv_state.ndim != 3 or conv_state.shape[0] != B or conv_state.shape[2] != C:
+        raise ValueError(
+            "tree conv state must be [B, kernel_size-1, channels] matching qkv"
+        )
+    n_keep = conv_state.shape[1]
+    if n_keep < 1:
+        raise ValueError("tree conv requires a kernel size of at least two")
+    kernel_size = n_keep + 1
+    if (
+        _TREE_CONV_WINDOW_KERNEL is not None
+        and mx.default_device() == mx.gpu
+        and qkv.dtype == conv_state.dtype
+    ):
+        threads = B * C
+        return _TREE_CONV_WINDOW_KERNEL(
+            inputs=[qkv, conv_state, parents],
+            template=[
+                ("InT", qkv.dtype), ("B", B), ("T", T),
+                ("C", C), ("KS", kernel_size),
+            ],
+            grid=((threads + 255) // 256 * 256, 1, 1),
+            threadgroup=(256, 1, 1),
+            output_shapes=[
+                (B, T, n_keep, C),
+                (B * T, kernel_size, C),
+            ],
+            output_dtypes=[qkv.dtype, qkv.dtype],
+        )
+
+    conv_states, windows = [], []
+    for t in range(T):
+        choices = mx.stack([conv_state, *conv_states], axis=1)
+        index = (parents[:, t] + 1).reshape(B, 1, 1, 1)
+        parent_state = mx.take_along_axis(choices, index, axis=1)[:, 0]
+        window = mx.concatenate([parent_state, qkv[:, t : t + 1]], axis=1)
+        windows.append(window)
+        conv_states.append(mx.contiguous(window[:, 1:]))
+    return (
+        mx.stack(conv_states, axis=1),
+        mx.stack(windows, axis=1).reshape(B * T, kernel_size, C),
+    )
+
+
 def gated_delta_zero_kernel(q, k, v, g, beta, state_type, mask=None):
     """Run the GDN recurrence from zero without allocating an input state."""
     B, T, Hk, Dk = k.shape
@@ -213,6 +476,205 @@ def gated_delta_zero_kernel(q, k, v, g, beta, state_type, mask=None):
         output_shapes=[(B, T, Hv, Dv), (B, Hv, Dv, Dk)],
         output_dtypes=[q.dtype, state_type],
     )
+
+
+def gated_delta_trace_update(q, k, v, a, b, A_log, dt_bias, state, mask=None):
+    """Return GDN output plus state after each position as ``[B,T,H,Dv,Dk]``."""
+    from mlx_lm.models import gated_delta
+
+    beta = mx.sigmoid(b)
+    g = gated_delta.compute_g(A_log, a, dt_bias)
+    if state is None:
+        B, _, _, Dk = q.shape
+        Hv, Dv = v.shape[-2:]
+        state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+
+    B, T, Hk, Dk = k.shape
+    Hv, Dv = v.shape[2:]
+    kernel = _TRACE_MASKED_KERNEL if mask is not None else _TRACE_KERNEL
+    if kernel is not None and mx.default_device() == mx.gpu:
+        inputs = [q, k, v, g, beta, state, T]
+        if mask is not None:
+            inputs.append(mask)
+        return kernel(
+            inputs=inputs,
+            template=[
+                ("InT", q.dtype),
+                ("StT", state.dtype),
+                ("Dk", Dk),
+                ("Dv", Dv),
+                ("Hk", Hk),
+                ("Hv", Hv),
+            ],
+            grid=(32, Dv, B * Hv),
+            threadgroup=(32, 4, 1),
+            output_shapes=[(B, T, Hv, Dv), (B, T, Hv, Dv, Dk)],
+            output_dtypes=[q.dtype, state.dtype],
+        )
+
+    # Portable reference for CPU tests. Keep the recurrence state at the
+    # precision mlx-lm's ops path chooses, and cast only captured snapshots.
+    if (repeat := Hv // Hk) > 1:
+        q = mx.repeat(q, repeat, -2)
+        k = mx.repeat(k, repeat, -2)
+    outputs, states = [], []
+    for t in range(T):
+        old_state = state
+        decay = g[:, t, :, None, None]
+        state = state * decay
+        kv_mem = (state * k[:, t, :, None, :]).sum(axis=-1)
+        delta = (v[:, t] - kv_mem) * beta[:, t, :, None]
+        state = state + k[:, t, :, None, :] * delta[..., None]
+        output = (state * q[:, t, :, None, :]).sum(axis=-1).astype(q.dtype)
+        if mask is not None:
+            active = mx.expand_dims(mask[:, t], axis=(1, 2, 3))
+            state = mx.where(active, state, old_state)
+            output = mx.where(mask[:, t, None, None], output, 0)
+        outputs.append(output)
+        states.append(state.astype(old_state.dtype))
+    return mx.stack(outputs, axis=1), mx.stack(states, axis=1)
+
+
+def gated_delta_tree_trace_update(
+    q, k, v, a, b, A_log, dt_bias, state, parents
+):
+    """Return outputs/states for topologically ordered tree nodes.
+
+    ``parents[b, t]`` is -1 for a child of the committed prefix, otherwise the
+    index of an earlier node in the same T-wide verification tree.
+    """
+    from mlx_lm.models import gated_delta
+
+    beta = mx.sigmoid(b)
+    g = gated_delta.compute_g(A_log, a, dt_bias)
+    if state is None:
+        B, _, _, Dk = q.shape
+        Hv, Dv = v.shape[-2:]
+        state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+
+    B, T, Hk, Dk = k.shape
+    Hv, Dv = v.shape[2:]
+    parents = parents.astype(mx.int32)
+    if _TREE_TRACE_KERNEL is not None and mx.default_device() == mx.gpu:
+        return _TREE_TRACE_KERNEL(
+            inputs=[q, k, v, g, beta, state, parents, T],
+            template=[
+                ("InT", q.dtype),
+                ("StT", state.dtype),
+                ("Dk", Dk),
+                ("Dv", Dv),
+                ("Hk", Hk),
+                ("Hv", Hv),
+            ],
+            grid=(32, Dv, B * Hv),
+            threadgroup=(32, 4, 1),
+            output_shapes=[(B, T, Hv, Dv), (B, T, Hv, Dv, Dk)],
+            output_dtypes=[q.dtype, state.dtype],
+        )
+
+    if (repeat := Hv // Hk) > 1:
+        q = mx.repeat(q, repeat, -2)
+        k = mx.repeat(k, repeat, -2)
+    outputs, states = [], []
+    for t in range(T):
+        choices = mx.stack([state, *states], axis=1)
+        index = (parents[:, t] + 1).reshape(B, 1, 1, 1, 1)
+        parent_state = mx.take_along_axis(choices, index, axis=1)[:, 0]
+        next_state = parent_state * g[:, t, :, None, None]
+        kv_mem = (next_state * k[:, t, :, None, :]).sum(axis=-1)
+        delta = (v[:, t] - kv_mem) * beta[:, t, :, None]
+        next_state = next_state + k[:, t, :, None, :] * delta[..., None]
+        output = (next_state * q[:, t, :, None, :]).sum(axis=-1).astype(q.dtype)
+        states.append(next_state.astype(state.dtype))
+        outputs.append(output)
+    return mx.stack(outputs, axis=1), mx.stack(states, axis=1)
+
+
+def trace_gdn_forward(self, inputs, mask=None, cache=None, *, tree_parents=None):
+    """Run one GatedDeltaNet layer and return its speculative state trace.
+
+    This is called explicitly by the MTP verifier. Keeping the trace transaction
+    in the caller avoids process-global state and leaves mlx-lm's class untouched.
+    """
+    if cache is None or cache.lengths is not None or self.sharding_group is not None:
+        raise ValueError("MTP GDN tracing currently requires an unpadded local cache")
+
+    B, S, _ = inputs.shape
+    qkv, z = _project_qkv_z(self, inputs)
+    z = z.reshape(B, S, self.num_v_heads, self.head_v_dim)
+    b = self.in_proj_b(inputs)
+    a = self.in_proj_a(inputs)
+
+    conv_state = cache[0]
+    if conv_state is None:
+        conv_state = mx.zeros(
+            (B, self.conv_kernel_size - 1, self.conv_dim), dtype=inputs.dtype
+        )
+    n_keep = self.conv_kernel_size - 1
+    if tree_parents is None:
+        conv_input = mx.concatenate([conv_state, qkv], axis=1)
+        cache[0] = mx.contiguous(conv_input[:, -n_keep:, :])
+        conv_trace = mx.stack(
+            [mx.contiguous(conv_input[:, t : t + n_keep, :])
+             for t in range(1, S + 1)],
+            axis=1,
+        )
+        conv_out = nn.silu(self.conv1d(conv_input))
+    else:
+        conv_trace, window_batch = tree_conv_windows(qkv, conv_state, tree_parents)
+        cache[0] = conv_trace[:, -1]
+        # Treat every node as a separate length-one convolution while keeping
+        # all candidates in one projection/conv graph.
+        conv_out = nn.silu(self.conv1d(window_batch)).reshape(B, S, self.conv_dim)
+
+    q, k, v = [
+        tensor.reshape(B, S, heads, dim)
+        for tensor, heads, dim in zip(
+            mx.split(conv_out, [self.key_dim, 2 * self.key_dim], -1),
+            [self.num_k_heads, self.num_k_heads, self.num_v_heads],
+            [self.head_k_dim, self.head_k_dim, self.head_v_dim],
+        )
+    ]
+    inv_scale = k.shape[-1] ** -0.5
+    q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+    k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+    if tree_parents is None:
+        output, state_trace = gated_delta_trace_update(
+            q, k, v, a, b, self.A_log, self.dt_bias, cache[1], mask
+        )
+    else:
+        output, state_trace = gated_delta_tree_trace_update(
+            q, k, v, a, b, self.A_log, self.dt_bias, cache[1],
+            tree_parents,
+        )
+    cache[1] = state_trace[:, -1]
+    cache.advance(S)
+
+    output = self.norm(output, z)
+    output = self.out_proj(output.reshape(B, S, -1))
+    return output, (cache, conv_trace, state_trace)
+
+
+def _project_qkv_z(module, inputs):
+    """Share one small-row coded projection dispatch in traced GDN forwards."""
+    from .dense import EschaLinear, project_pair
+
+    if isinstance(module.in_proj_qkv, EschaLinear) and isinstance(
+        module.in_proj_z, EschaLinear
+    ):
+        return project_pair(module.in_proj_qkv, module.in_proj_z, inputs)
+    return module.in_proj_qkv(inputs), module.in_proj_z(inputs)
+
+
+def commit_tree_states(trace, positions) -> None:
+    """Commit a potentially different accepted tree node for every batch row."""
+    positions = mx.array(positions).astype(mx.int32)
+    B = positions.size
+    for cache, conv_states, recurrent_states in trace:
+        conv_index = positions.reshape(B, 1, 1, 1)
+        state_index = positions.reshape(B, 1, 1, 1, 1)
+        cache[0] = mx.take_along_axis(conv_states, conv_index, axis=1)[:, 0]
+        cache[1] = mx.take_along_axis(recurrent_states, state_index, axis=1)[:, 0]
 
 
 def _gated_delta_update(q, k, v, a, b, A_log, dt_bias, state=None,

--- a/escha_mlx/generate.py
+++ b/escha_mlx/generate.py
@@ -47,18 +47,23 @@ def main() -> None:
                          "keeps its own default; a template that does not use it "
                          "ignores it.")
     ap.add_argument("--temp", type=float, default=0.0, help="0 = greedy")
+    ap.add_argument(
+        "--mtp",
+        action="store_true",
+        help="load the checkpoint's pretrained MTP layer and use speculative decoding",
+    )
     ap.add_argument("-v", "--verbose", action="store_true")
     args = ap.parse_args()
     logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING,
                         format="%(levelname)s %(name)s: %(message)s")
 
-    from mlx_lm.generate import stream_generate
+    from mlx_lm.generate import stream_generate as mlx_stream_generate
     from mlx_lm.sample_utils import make_sampler
 
     from .loader import load
 
     t0 = time.time()
-    model, tokenizer = load(args.model)
+    model, tokenizer = load(args.model, load_mtp=args.mtp)
     print(f"[escha-mlx] model loaded in {time.time() - t0:.1f}s")
 
     if args.raw:
@@ -70,9 +75,15 @@ def main() -> None:
             **template_kwargs(args.thinking, args.reasoning_effort))
 
     sampler = make_sampler(temp=args.temp)
+    if args.mtp:
+        from .mtp import stream_generate
+
+        generate = stream_generate
+    else:
+        generate = mlx_stream_generate
     last = None
-    for r in stream_generate(model, tokenizer, prompt,
-                             max_tokens=args.max_tokens, sampler=sampler):
+    for r in generate(model, tokenizer, prompt, max_tokens=args.max_tokens,
+                      sampler=sampler):
         print(r.text, end="", flush=True)
         last = r
     print()

--- a/escha_mlx/loader.py
+++ b/escha_mlx/loader.py
@@ -145,8 +145,8 @@ def use_last_logit() -> bool:
     return bool(envs.ESCHA_MLX_LAST_LOGIT.get())
 
 
-def load_model(path: str | Path):
-    """Build the model. Returns the mlx-lm Model instance (module-swapped)."""
+def load_model(path: str | Path, *, load_mtp: bool = False):
+    """Build the model, optionally attaching its native pretrained MTP head."""
     # Fail on malformed process configuration before allocating weights or a
     # server can report ready and defer the error to its first request.
     envs.validate_environment()
@@ -174,12 +174,24 @@ def load_model(path: str | Path):
     mx.eval(model.parameters())
     mx.eval(escha_arrays)
     model.eval()
+    if install_fusion := getattr(arch, "install_projection_fusion", None):
+        install_fusion(model)
+    if load_mtp:
+        if arch.MODEL_TYPE != "qwen3_5":
+            raise ValueError(
+                f"MTP is only supported for qwen3_5 dense checkpoints, got "
+                f"{arch.MODEL_TYPE}"
+            )
+        from .mtp import load_mtp as _load_mtp
+
+        model.mtp = _load_mtp(path, model)
     logger.info("escha_mlx: %s model ready in %.1fs",
                 arch.MODEL_TYPE, time.time() - t0)
     return model
 
 
-def load(path: str | Path, tokenizer_config: dict | None = None, **_ignored):
+def load(path: str | Path, tokenizer_config: dict | None = None,
+         *, load_mtp: bool = False, **_ignored):
     """(model, tokenizer) — signature-compatible with mlx_lm.utils.load.
 
     Mirrors mlx_lm's eos handling: generation_config.json's eos_token_id list
@@ -205,7 +217,7 @@ def load(path: str | Path, tokenizer_config: dict | None = None, **_ignored):
         eos = json.loads(gen_cfg.read_text()).get("eos_token_id")
         if eos is not None:
             eos_ids = eos if isinstance(eos, list) else [eos]
-    model = load_model(path)
+    model = load_model(path, load_mtp=load_mtp)
     tokenizer = load_tokenizer(path, tokenizer_config_extra=tokenizer_config or {},
                                eos_token_ids=eos_ids)
     return model, tokenizer

--- a/escha_mlx/models/qwen3_5.py
+++ b/escha_mlx/models/qwen3_5.py
@@ -43,6 +43,7 @@ from __future__ import annotations
 import logging
 
 import mlx.core as mx
+import mlx.nn as nn
 import numpy as np
 from mlx.utils import tree_unflatten
 
@@ -57,6 +58,144 @@ MODEL_TYPE = "qwen3_5"
 #: exclusive to this format (a plain module could carry one), so it is held
 #: separately and only claimed by a base that turns out to be coded.
 _CODED_LEAVES = frozenset(l for l in dense.LEAVES if l.startswith("escha_"))
+
+
+class _FusedMLP(nn.Module):
+    """Qwen3.5 MLP with one coded dispatch for gate/up."""
+
+    def __init__(self, inner):
+        super().__init__()
+        self.inner = inner
+
+    @property
+    def gate_proj(self):
+        return self.inner.gate_proj
+
+    @property
+    def up_proj(self):
+        return self.inner.up_proj
+
+    @property
+    def down_proj(self):
+        return self.inner.down_proj
+
+    def __call__(self, x):
+        from mlx_lm.models.activations import swiglu
+
+        gate, up = dense.project_pair(self.gate_proj, self.up_proj, x)
+        return self.down_proj(swiglu(gate, up))
+
+
+class _FusedAttention(nn.Module):
+    """Qwen3.5 attention with one coded dispatch for K/V."""
+
+    def __init__(self, inner):
+        super().__init__()
+        self.inner = inner
+
+    @property
+    def q_proj(self):
+        return self.inner.q_proj
+
+    @property
+    def k_proj(self):
+        return self.inner.k_proj
+
+    @property
+    def v_proj(self):
+        return self.inner.v_proj
+
+    @property
+    def o_proj(self):
+        return self.inner.o_proj
+
+    @property
+    def q_norm(self):
+        return self.inner.q_norm
+
+    @property
+    def k_norm(self):
+        return self.inner.k_norm
+
+    @property
+    def rope(self):
+        return self.inner.rope
+
+    @property
+    def num_attention_heads(self):
+        return self.inner.num_attention_heads
+
+    @property
+    def num_key_value_heads(self):
+        return self.inner.num_key_value_heads
+
+    @property
+    def scale(self):
+        return self.inner.scale
+
+    def __call__(self, x, mask=None, cache=None):
+        from mlx_lm.models.base import scaled_dot_product_attention
+
+        B, L, _ = x.shape
+        q_output = self.inner.q_proj(x)
+        queries, gate = mx.split(
+            q_output.reshape(B, L, self.inner.num_attention_heads, -1),
+            2,
+            axis=-1,
+        )
+        gate = gate.reshape(B, L, -1)
+        keys, values = dense.project_pair(
+            self.inner.k_proj, self.inner.v_proj, x
+        )
+        queries = self.inner.q_norm(queries).transpose(0, 2, 1, 3)
+        keys = self.inner.k_norm(
+            keys.reshape(B, L, self.inner.num_key_value_heads, -1)
+        ).transpose(0, 2, 1, 3)
+        values = values.reshape(
+            B, L, self.inner.num_key_value_heads, -1
+        ).transpose(0, 2, 1, 3)
+        if cache is not None:
+            queries = self.inner.rope(queries, offset=cache.offset)
+            keys = self.inner.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.inner.rope(queries)
+            keys = self.inner.rope(keys)
+        output = scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            cache=cache,
+            scale=self.inner.scale,
+            mask=mask,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.inner.o_proj(output * mx.sigmoid(gate))
+
+
+def install_projection_fusion(model) -> int:
+    """Install the Qwen-specific wrappers around compatible coded linears."""
+    installed = 0
+    for layer in model.language_model.model.layers:
+        mlp = layer.mlp
+        if (
+            not isinstance(mlp, _FusedMLP)
+            and isinstance(mlp.gate_proj, dense.EschaLinear)
+            and isinstance(mlp.up_proj, dense.EschaLinear)
+        ):
+            layer.mlp = _FusedMLP(mlp)
+            installed += 1
+        if not layer.is_linear:
+            attention = layer.self_attn
+            if (
+                not isinstance(attention, _FusedAttention)
+                and isinstance(attention.k_proj, dense.EschaLinear)
+                and isinstance(attention.v_proj, dense.EschaLinear)
+            ):
+                layer.self_attn = _FusedAttention(attention)
+                installed += 1
+    logger.info("escha_mlx: installed %d dense projection-fusion groups", installed)
+    return installed
 
 
 class CheckpointLoader:
@@ -91,7 +230,9 @@ class CheckpointLoader:
     def _install_q8(self, base_name: str, pair: dict[str, np.ndarray]) -> None:
         w8, scale = pair["weight_int8"], pair["weight_scale"]
         if base_name == "lm_head":
-            self.model.language_model.lm_head = quant.make_linear(w8, scale, self.group_size)
+            self.model.language_model.lm_head = quant.make_head(
+                w8, scale, self.group_size
+            )
         elif base_name == "embed_tokens":
             self.model.language_model.model.embed_tokens = quant.make_embedding(
                 w8, scale, self.group_size)

--- a/escha_mlx/models/qwen3_5_moe.py
+++ b/escha_mlx/models/qwen3_5_moe.py
@@ -304,7 +304,9 @@ class CheckpointLoader:
     def _install_q8(self, base_name: str, pair: dict[str, np.ndarray]) -> None:
         w8, scale = pair["weight_int8"], pair["weight_scale"]
         if base_name == "lm_head":
-            self.model.language_model.lm_head = quant.make_linear(w8, scale, self.group_size)
+            self.model.language_model.lm_head = quant.make_head(
+                w8, scale, self.group_size
+            )
         elif base_name == "embed_tokens":
             self.model.language_model.model.embed_tokens = quant.make_embedding(
                 w8, scale, self.group_size)

--- a/escha_mlx/msl.py
+++ b/escha_mlx/msl.py
@@ -10,6 +10,9 @@ Two kernel families only — everything else in this package is pure MLX ops:
     channels of one row (8 simdgroups; simdgroup s handles output tile
     ocb*8+s).  Rows are single-token/single-expert ("row_expert" indexed),
     which keeps everything device-resident (no host sync in the MoE path).
+    Dense row-blocked variants share a decode across rows; the small-row
+    variant used by MTP verification reads up to eight consecutive rows
+    without barriers.
 
 Numeric contract (must match escha_mlx.ref bit-for-bit at the decode level):
   decode(x) = fp16_lo(r) + fp16_hi(r), r = ((x*0xCBAC1FED) & 0x8FFF8FFF) ^ 0x3B603B60
@@ -21,6 +24,7 @@ construction, built by ref.cba_lut on the host).
 from __future__ import annotations
 
 from functools import lru_cache
+import re
 
 import mlx.core as mx
 import numpy as np
@@ -431,6 +435,242 @@ def _moe_gemv_source(K: int, use_lut: bool, dense: bool = False) -> str:
 """
 
 
+def _dense_gemm_rows_direct_source(K: int, use_lut: bool, R: int) -> str:
+    """Small-row dense GEMM without input staging or barriers.
+
+    A dense group owns consecutive rows, so each simdgroup can address those
+    rows directly while decoding its weight tile once for all ``R`` rows.  For
+    the small M used by speculative verification, redundant input reads stay in
+    cache and cost less than staging ``R`` rows plus two barriers per tile
+    block.  Each row keeps the exact kt/j accumulation order of dense GEMV.
+    """
+    wpt = 8 * K
+    extract = _substitute_fetch(_EXTRACT_K2 if K == 2 else _EXTRACT_K3)
+    decs = "\n".join(
+        f"        float d{j} = (float){_dec(f's{j}', use_lut)};"
+        for j in range(8)
+    )
+    return f"""
+    uint ocb = thread_position_in_grid.x >> 8;
+    uint grp = thread_position_in_grid.y;
+    uint lane = thread_index_in_simdgroup;
+    uint sg = simdgroup_index_in_threadgroup;
+    if (grp * {R}u >= (uint)M) return;
+
+    float acc0[{R}], acc1[{R}];
+#pragma clang loop unroll(full)
+    for (uint r = 0; r < {R}u; ++r) {{ acc0[r] = 0.0f; acc1[r] = 0.0f; }}
+
+    uint l0 = lane & ~4u;
+    uint c_off = (lane >> 2) & 1u;
+    uint xrow = (lane & 3u) * 2u;
+
+    for (uint kt = 0; kt < TK; ++kt) {{
+        device const uint* wp = code
+            + ((ulong)kt * TN + ocb * 8u + sg) * {wpt}u;
+{extract}
+{decs}
+#pragma clang loop unroll(full)
+        for (uint r = 0; r < {R}u; ++r) {{
+            uint row = min(grp * {R}u + r, (uint)M - 1u);
+            device const half2* xp = (device const half2*)(
+                xh + (ulong)row * IC + kt * 16u + xrow);
+            half2 xv0 = xp[0];
+            half2 xv1 = xp[4];
+            acc0[r] += (float)xv0.x * d0;
+            acc0[r] += (float)xv0.y * d1;
+            acc0[r] += (float)xv1.x * d2;
+            acc0[r] += (float)xv1.y * d3;
+            acc1[r] += (float)xv0.x * d4;
+            acc1[r] += (float)xv0.y * d5;
+            acc1[r] += (float)xv1.x * d6;
+            acc1[r] += (float)xv1.y * d7;
+        }}
+    }}
+
+#pragma clang loop unroll(full)
+    for (uint r = 0; r < {R}u; ++r) {{
+        float a0 = acc0[r], a1 = acc1[r];
+        a0 += simd_shuffle_xor(a0, 1u);
+        a0 += simd_shuffle_xor(a0, 2u);
+        a1 += simd_shuffle_xor(a1, 1u);
+        a1 += simd_shuffle_xor(a1, 2u);
+        if ((lane & 3u) == 0u && grp * {R}u + r < (uint)M) {{
+            uint col = 2u * (l0 >> 3) + c_off;
+            ulong ob = (ulong)(grp * {R}u + r) * OC
+                     + ocb * 128u + sg * 16u;
+            mid[ob + col] = a0;
+            mid[ob + col + 8u] = a1;
+        }}
+    }}
+"""
+
+
+def _dense_gemm_rows_direct_out_source(
+    K: int, use_lut: bool, R: int, rs: float
+) -> str:
+    """Small-row GEMM with output Hadamard/rout in its epilogue."""
+    wpt = 8 * K
+    extract = _substitute_fetch(_EXTRACT_K2 if K == 2 else _EXTRACT_K3)
+    decs = "\n".join(
+        f"        float d{j} = (float){_dec(f's{j}', use_lut)};"
+        for j in range(8)
+    )
+    return f"""
+    uint tid = thread_position_in_threadgroup.x;
+    uint ocb = thread_position_in_grid.x >> 8;
+    uint grp = thread_position_in_grid.y;
+    uint lane = thread_index_in_simdgroup;
+    uint sg = simdgroup_index_in_threadgroup;
+    if (grp * {R}u >= (uint)M) return;
+
+    float acc0[{R}], acc1[{R}];
+    threadgroup float s_mid[{R * 128}];
+#pragma clang loop unroll(full)
+    for (uint r = 0; r < {R}u; ++r) {{ acc0[r] = 0.0f; acc1[r] = 0.0f; }}
+    uint l0 = lane & ~4u;
+    uint c_off = (lane >> 2) & 1u;
+    uint xrow = (lane & 3u) * 2u;
+
+    for (uint kt = 0; kt < TK; ++kt) {{
+        device const uint* wp = code
+            + ((ulong)kt * TN + ocb * 8u + sg) * {wpt}u;
+{extract}
+{decs}
+#pragma clang loop unroll(full)
+        for (uint r = 0; r < {R}u; ++r) {{
+            uint row = min(grp * {R}u + r, (uint)M - 1u);
+            device const half2* xp = (device const half2*)(
+                xh + (ulong)row * IC + kt * 16u + xrow);
+            half2 xv0 = xp[0], xv1 = xp[4];
+            acc0[r] += (float)xv0.x * d0;
+            acc0[r] += (float)xv0.y * d1;
+            acc0[r] += (float)xv1.x * d2;
+            acc0[r] += (float)xv1.y * d3;
+            acc1[r] += (float)xv0.x * d4;
+            acc1[r] += (float)xv0.y * d5;
+            acc1[r] += (float)xv1.x * d6;
+            acc1[r] += (float)xv1.y * d7;
+        }}
+    }}
+
+#pragma clang loop unroll(full)
+    for (uint r = 0; r < {R}u; ++r) {{
+        float a0 = acc0[r], a1 = acc1[r];
+        a0 += simd_shuffle_xor(a0, 1u);
+        a0 += simd_shuffle_xor(a0, 2u);
+        a1 += simd_shuffle_xor(a1, 1u);
+        a1 += simd_shuffle_xor(a1, 2u);
+        if ((lane & 3u) == 0u) {{
+            uint col = 2u * (l0 >> 3) + c_off;
+            uint sb = r * 128u + sg * 16u;
+            s_mid[sb + col] = a0;
+            s_mid[sb + col + 8u] = a1;
+        }}
+    }}
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    // The GEMM group owns exactly one 128-channel output block, so its 256
+    // threads can reuse the completed accumulator tile for the WHT. Only the
+    // first 128 threads update values; all threads participate in barriers.
+#pragma clang loop unroll(full)
+    for (uint r = 0; r < {R}u; ++r) {{
+#pragma clang loop unroll(full)
+        for (uint stage = 0; stage < 7u; ++stage) {{
+            uint mask = 1u << stage;
+            float mine = 0.0f, other = 0.0f;
+            if (tid < 128u) {{
+                mine = s_mid[r * 128u + tid];
+                other = s_mid[r * 128u + (tid ^ mask)];
+            }}
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+            if (tid < 128u)
+                s_mid[r * 128u + tid] = (tid & mask) ? (other - mine) : (mine + other);
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }}
+        if (tid < 128u && grp * {R}u + r < (uint)M) {{
+            ulong off = (ulong)(grp * {R}u + r) * OC + ocb * 128u + tid;
+            float scaled = s_mid[r * 128u + tid] * {rs!r}f;
+            out[off] = (half)(scaled * rout[ocb * 128u + tid]);
+        }}
+    }}
+"""
+
+
+def _dense_gemm_pair_out_source(
+    K0: int, K1: int, use_lut: bool, R: int, rs: float
+) -> str:
+    def shard(k, suffix, offset):
+        body = _dense_gemm_rows_direct_out_source(k, use_lut, R, rs)
+        body = body.replace(
+            "uint ocb = thread_position_in_grid.x >> 8;",
+            f"uint ocb = block - (uint){offset};",
+        )
+        for old, new in (
+            ("code", f"code{suffix}"),
+            ("xh", f"xh{suffix}"),
+            ("rout", f"rout{suffix}"),
+            ("out", f"out{suffix}"),
+            ("TN", f"TN{suffix}"),
+            ("OC", f"OC{suffix}"),
+        ):
+            body = re.sub(rf"\b{old}\b", new, body)
+        return body
+
+    first = shard(K0, 0, 0)
+    second = shard(K1, 1, "TN0 / 8")
+    return f"""
+    uint block = thread_position_in_grid.x >> 8;
+    if (block < (uint)(TN0 / 8)) {{
+{first}
+    }} else {{
+{second}
+    }}
+"""
+
+
+def _dense_gemm_pair_source(
+    K0: int, K1: int, use_lut: bool, R: int, KB: int, direct: bool
+) -> str:
+    """Turn one row-blocked body into a two-projection dispatch.
+
+    Gate/up and K/V have the same input row geometry but distinct transforms
+    and coded streams.  A uniform branch per threadgroup selects the shard;
+    there is no lane divergence and the scalar accumulation order is unchanged.
+    """
+    def shard_body(k, suffix, block_offset):
+        if direct:
+            body = _dense_gemm_rows_direct_source(k, use_lut, R)
+        else:
+            body = _moe_gemm_rows_source(
+                k, use_lut, R, KB, False, use_prefetch(), True
+            )
+        body = body.replace(
+            "uint ocb = thread_position_in_grid.x >> 8;",
+            f"uint ocb = block - (uint){block_offset};",
+        )
+        for old, new in (
+            ("code", f"code{suffix}"),
+            ("xh", f"xh{suffix}"),
+            ("mid", f"mid{suffix}"),
+            ("TN", f"TN{suffix}"),
+            ("OC", f"OC{suffix}"),
+        ):
+            body = re.sub(rf"\b{old}\b", new, body)
+        return body
+
+    first = shard_body(K0, 0, 0)
+    second = shard_body(K1, 1, "TN0 / 8")
+    return f"""
+    uint block = thread_position_in_grid.x >> 8;
+    if (block < (uint)(TN0 / 8)) {{
+{first}
+    }} else {{
+{second}
+    }}
+"""
+
+
 def _gemm_group_prologue(R: int, dense: bool) -> str:
     """Group-validity prologue for the row-blocked GEMM.
 
@@ -709,6 +949,34 @@ def _scaled_had_out_source(rs: float, dense: bool = False) -> str:
 """
 
 
+def _dense_scaled_had_pair_source(rs: float, output: bool) -> str:
+    """Two independent dense Hadamard projections in one dispatch."""
+    make = _scaled_had_out_source if output else _scaled_had_source
+    source = make(rs, True)
+    dim = "OC" if output else "IC"
+    block_line = "uint blk = thread_position_in_grid.x >> 7;"
+
+    def shard(suffix, offset):
+        body = source.replace(block_line, f"uint blk = block - (uint){offset};")
+        names = (("mid", f"mid{suffix}"), ("rout", f"rout{suffix}")) if output else (
+            ("rows", "rows"), ("rin", f"rin{suffix}")
+        )
+        for old, new in (*names, ("out", f"out{suffix}"), (dim, f"{dim}{suffix}")):
+            body = re.sub(rf"\b{old}\b", new, body)
+        return body
+
+    first = shard(0, 0)
+    second = shard(1, f"{dim}0 / 128")
+    return f"""
+    uint block = thread_position_in_grid.x >> 7;
+    if (block < (uint)({dim}0 / 128)) {{
+{first}
+    }} else {{
+{second}
+    }}
+"""
+
+
 # The kernel NAME is part of MLX's compiled-kernel identity, so every source
 # variant must contribute to it.  A dense kernel compiled under the MoE name
 # would be served from the cache to the MoE path (and vice versa) with no
@@ -734,6 +1002,22 @@ def _scaled_had_out_kernel(rs: float, dense: bool = False):
         input_names=["mid", "rout"] + ([] if dense else ["row_expert"]),
         output_names=["out"],
         source=_scaled_had_out_source(rs, dense),
+    )
+
+
+@lru_cache(maxsize=None)
+def _dense_scaled_had_pair_kernel(rs: float, output: bool):
+    if output:
+        inputs = ["mid0", "mid1", "rout0", "rout1"]
+        stem = "escha_scaled_had_out_pair"
+    else:
+        inputs = ["rows", "rin0", "rin1"]
+        stem = "escha_scaled_had_pair"
+    return mx.fast.metal_kernel(
+        name=stem,
+        input_names=inputs,
+        output_names=["out0", "out1"],
+        source=_dense_scaled_had_pair_source(rs, output),
     )
 
 
@@ -1026,6 +1310,59 @@ def _moe_gemm_rows_kernel(K: int, lut: bool, R: int, KB: int = 1,
     )
 
 
+@lru_cache(maxsize=None)
+def _dense_gemm_rows_direct_kernel(K: int, lut: bool, R: int):
+    return mx.fast.metal_kernel(
+        name=f"escha_gemm_dense_direct_k{K}_r{R}"
+        f"{'_lut' if lut else ''}",
+        input_names=["xh", "code"] + (["lut"] if lut else []),
+        output_names=["mid"],
+        header=_HEADER,
+        source=_dense_gemm_rows_direct_source(K, lut, R),
+    )
+
+
+@lru_cache(maxsize=None)
+def _dense_gemm_rows_direct_out_kernel(K: int, lut: bool, R: int, rs: float):
+    return mx.fast.metal_kernel(
+        name=f"escha_gemm_dense_direct_out_k{K}_r{R}"
+        f"{'_lut' if lut else ''}",
+        input_names=["xh", "code", "rout"] + (["lut"] if lut else []),
+        output_names=["out"],
+        header=_HEADER,
+        source=_dense_gemm_rows_direct_out_source(K, lut, R, rs),
+    )
+
+
+@lru_cache(maxsize=None)
+def _dense_gemm_pair_out_kernel(K0: int, K1: int, lut: bool, R: int, rs: float):
+    return mx.fast.metal_kernel(
+        name=f"escha_gemm_dense_pair_out_k{K0}{K1}_r{R}"
+        f"{'_lut' if lut else ''}",
+        input_names=[
+            "xh0", "xh1", "code0", "code1", "rout0", "rout1"
+        ] + (["lut"] if lut else []),
+        output_names=["out0", "out1"],
+        header=_HEADER,
+        source=_dense_gemm_pair_out_source(K0, K1, lut, R, rs),
+    )
+
+
+@lru_cache(maxsize=None)
+def _dense_gemm_pair_kernel(
+    K0: int, K1: int, lut: bool, R: int, KB: int, direct: bool
+):
+    return mx.fast.metal_kernel(
+        name=f"escha_gemm_dense_pair_k{K0}{K1}_r{R}_kb{KB}"
+        f"{'_direct' if direct else ''}{'_lut' if lut else ''}",
+        input_names=["xh0", "xh1", "code0", "code1"]
+        + (["lut"] if lut else []),
+        output_names=["mid0", "mid1"],
+        header=_HEADER,
+        source=_dense_gemm_pair_source(K0, K1, lut, R, KB, direct),
+    )
+
+
 def moe_gemm_rows(xh: mx.array, code_u32: mx.array, rows_idx: mx.array,
                   group_expert: mx.array, K: int, IC: int, OC: int,
                   R: int, n_rows: int, sort_idx=None) -> mx.array:
@@ -1149,6 +1486,45 @@ def dense_scaled_had(rows: mx.array, rin: mx.array, rs: float) -> mx.array:
 def dense_scaled_had_out(mid: mx.array, rout: mx.array, rs: float) -> mx.array:
     """f16( H128(mid) * RS * rout ) for a dense linear. rout [OC] f32."""
     return scaled_had_out(mid, rout, None, rs)
+
+
+def dense_scaled_had_pair(
+    rows: mx.array, rin0: mx.array, rin1: mx.array, rs: float
+) -> tuple[mx.array, mx.array]:
+    """Two dense input transforms in one sharded dispatch."""
+    m, ic = rows.shape
+    kernel = _dense_scaled_had_pair_kernel(float(rs), False)
+    return kernel(
+        inputs=[rows, rin0, rin1],
+        template=[("IC0", ic), ("IC1", ic)],
+        grid=(256 * (ic // 128), m, 1),
+        threadgroup=(128, 1, 1),
+        output_shapes=[(m, ic), (m, ic)],
+        output_dtypes=[mx.float16, mx.float16],
+    )
+
+
+def dense_scaled_had_out_pair(
+    mid0: mx.array,
+    mid1: mx.array,
+    rout0: mx.array,
+    rout1: mx.array,
+    rs: float,
+) -> tuple[mx.array, mx.array]:
+    """Two dense output transforms in one sharded dispatch."""
+    m, oc0 = mid0.shape
+    if mid1.shape[0] != m:
+        raise ValueError("output transform pair requires equal row counts")
+    oc1 = mid1.shape[1]
+    kernel = _dense_scaled_had_pair_kernel(float(rs), True)
+    return kernel(
+        inputs=[mid0, mid1, rout0, rout1],
+        template=[("OC0", oc0), ("OC1", oc1)],
+        grid=(128 * ((oc0 + oc1) // 128), m, 1),
+        threadgroup=(128, 1, 1),
+        output_shapes=[(m, oc0), (m, oc1)],
+        output_dtypes=[mx.float16, mx.float16],
+    )
 
 
 def dense_gemv(xh: mx.array, code_u32: mx.array, K: int, IC: int, OC: int,
@@ -1351,7 +1727,7 @@ DENSE_MAT_R = 16
 
 
 def use_dense_mat() -> bool:
-    """simdgroup-matrix dense GEMM. DEFAULT OFF -- deterministic, NOT bit-identical.
+    """Experimental simdgroup-matrix dense GEMM. DEFAULT OFF.
 
     Enabled with ESCHA_MLX_DENSE_MAT=1.  Off by default for the same reason
     split-K is: every other kernel in this runtime is bit-identical to the
@@ -1363,11 +1739,11 @@ def use_dense_mat() -> bool:
 
         prefill ISL 512    38.9 -> 45.5 tok/s  (+17.0%)
         prefill ISL 2048   38.0 -> 44.1 tok/s  (+16.0%)
-        decode  bs1         7.05 -> 7.01 tok/s (noise -- see below)
+        decode  bs1         7.05 -> 7.01 tok/s (noise)
 
-    Decode is untouched by construction: at bs1 the row count is 1, the size
-    policy returns R=1, and this kernel is never reached.  It is a prefill/TTFT
-    lever only.  Reproduce with
+    Ordinary bs1 decode is untouched because its row count is one. This flag
+    applies only to the measured R=16 prefill path; the slower M=4/8 matrix
+    experiment is intentionally not part of the runtime. Reproduce with
     ``bench/prefill_profile.py --sweep-dense-mat``.
 
     The obvious next step does NOT pay here.  Swapping the float8x8 accumulator
@@ -1434,3 +1810,141 @@ def dense_gemm_rows(xh: mx.array, code_u32: mx.array, K: int, IC: int, OC: int,
         output_dtypes=[mx.float32],
     )
     return mid
+
+
+def dense_gemm_rows_direct(
+    xh: mx.array, code_u32: mx.array, K: int, IC: int, OC: int, R: int
+) -> mx.array:
+    """Barrier-free row-blocked dense GEMM for small ``R``."""
+    m = xh.shape[0]
+    if m < 1:
+        raise ValueError("dense_gemm_rows_direct needs at least one row")
+    if R < 2:
+        return dense_gemv(xh, code_u32, K, IC, OC)
+    lut = use_lut()
+    kern = _dense_gemm_rows_direct_kernel(K, lut, R)
+    inputs = [xh, code_u32.reshape(-1)] + ([_lut_array()] if lut else [])
+    (mid,) = kern(
+        inputs=inputs,
+        template=[
+            ("TK", IC // 16),
+            ("TN", OC // 16),
+            ("IC", IC),
+            ("OC", OC),
+            ("M", m),
+        ],
+        grid=(256 * (OC // 128), (m + R - 1) // R, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(m, OC)],
+        output_dtypes=[mx.float32],
+    )
+    return mid
+
+
+def dense_gemm_rows_direct_out(
+    xh: mx.array,
+    code: mx.array,
+    rout: mx.array,
+    K: int,
+    IC: int,
+    OC: int,
+    R: int,
+    rs: float,
+) -> mx.array:
+    """Barrier-free small-row GEMM with its output transform fused."""
+    m = xh.shape[0]
+    lut = use_lut()
+    kernel = _dense_gemm_rows_direct_out_kernel(K, lut, R, float(rs))
+    inputs = [xh, code.reshape(-1), rout] + ([_lut_array()] if lut else [])
+    (out,) = kernel(
+        inputs=inputs,
+        template=[
+            ("TK", IC // 16), ("TN", OC // 16), ("IC", IC), ("OC", OC),
+            ("M", m),
+        ],
+        grid=(256 * (OC // 128), (m + R - 1) // R, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(m, OC)],
+        output_dtypes=[mx.float16],
+    )
+    return out
+
+
+def dense_gemm_pair_out(
+    xh0: mx.array,
+    xh1: mx.array,
+    code0: mx.array,
+    code1: mx.array,
+    rout0: mx.array,
+    rout1: mx.array,
+    K0: int,
+    K1: int,
+    IC: int,
+    OC0: int,
+    OC1: int,
+    R: int,
+    rs: float,
+) -> tuple[mx.array, mx.array]:
+    """Mixed-K projection pair with both output transforms fused."""
+    m = xh0.shape[0]
+    lut = use_lut()
+    kernel = _dense_gemm_pair_out_kernel(K0, K1, lut, R, float(rs))
+    inputs = [
+        xh0, xh1, code0.reshape(-1), code1.reshape(-1), rout0, rout1
+    ] + ([_lut_array()] if lut else [])
+    return kernel(
+        inputs=inputs,
+        template=[
+            ("TK", IC // 16),
+            ("TN0", OC0 // 16), ("TN1", OC1 // 16),
+            ("IC", IC), ("OC0", OC0), ("OC1", OC1), ("M", m),
+        ],
+        grid=(256 * ((OC0 + OC1) // 128), (m + R - 1) // R, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(m, OC0), (m, OC1)],
+        output_dtypes=[mx.float16, mx.float16],
+    )
+
+
+def dense_gemm_pair(
+    xh0: mx.array,
+    xh1: mx.array,
+    code0: mx.array,
+    code1: mx.array,
+    K0: int,
+    K1: int,
+    IC: int,
+    OC0: int,
+    OC1: int,
+    R: int,
+) -> tuple[mx.array, mx.array]:
+    """Two coded projections in one uniform-sharded Metal dispatch."""
+    if xh0.shape != xh1.shape or xh0.shape[0] < 1:
+        raise ValueError("dense_gemm_pair requires matching non-empty input rows")
+    m = xh0.shape[0]
+    tk = IC // 16
+    direct = R <= 8
+    kb = 1 if direct else kt_block()
+    if tk % kb:
+        kb = 1
+    lut = use_lut()
+    kernel = _dense_gemm_pair_kernel(K0, K1, lut, R, kb, direct)
+    inputs = [xh0, xh1, code0.reshape(-1), code1.reshape(-1)]
+    if lut:
+        inputs.append(_lut_array())
+    return kernel(
+        inputs=inputs,
+        template=[
+            ("TK", tk),
+            ("TN0", OC0 // 16),
+            ("TN1", OC1 // 16),
+            ("IC", IC),
+            ("OC0", OC0),
+            ("OC1", OC1),
+            ("M", m),
+        ],
+        grid=(256 * ((OC0 + OC1) // 128), (m + R - 1) // R, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(m, OC0), (m, OC1)],
+        output_dtypes=[mx.float32, mx.float32],
+    )

--- a/escha_mlx/mtp.py
+++ b/escha_mlx/mtp.py
@@ -1,0 +1,892 @@
+"""Qwen3.8 native multi-token-prediction head and speculative generation.
+
+The checkpoint's ``mtp/`` directory is not a standalone language model.  It is
+one full-attention Qwen3.5 decoder layer which consumes the target model's
+hidden state together with the embedding of the following token.  Its token
+embedding and language-model head are shared with the target.
+
+The Apple-Metal path uses a topk=3, depth=3 tree with three selected draft
+nodes plus the verified root (M=4 target verification).
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Callable, Generator, Iterable
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten
+
+logger = logging.getLogger(__name__)
+
+_NORM_WEIGHTS = frozenset(
+    {
+        "pre_fc_norm_embedding.weight",
+        "pre_fc_norm_hidden.weight",
+        "layers.0.input_layernorm.weight",
+        "layers.0.post_attention_layernorm.weight",
+        "layers.0.self_attn.q_norm.weight",
+        "layers.0.self_attn.k_norm.weight",
+        "norm.weight",
+    }
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class _TreeSpec:
+    """Proposal geometry; the shipped policy remains one measured fixed value."""
+
+    topk: int
+    depth: int
+    draft_nodes: int
+
+    def __post_init__(self):
+        candidates = self.topk + max(0, self.depth - 1) * self.topk**2
+        if self.topk < 1 or self.depth < 1:
+            raise ValueError("MTP tree topk and depth must be positive")
+        if not 1 <= self.draft_nodes <= candidates:
+            raise ValueError(
+                f"MTP tree draft_nodes must be in [1, {candidates}]"
+            )
+
+
+_DEFAULT_TREE_SPEC = _TreeSpec(topk=3, depth=3, draft_nodes=3)
+
+
+def _unwrapped_head(model) -> nn.Module:
+    """Return the target head without the last-position optimization wrapper."""
+    head = model.language_model.lm_head
+    # Avoid importing loader.LastPositionHead here: loader imports this module
+    # lazily when MTP is requested.
+    return getattr(head, "inner", head)
+
+
+def _target_logits(model, hidden: mx.array) -> mx.array:
+    lm = model.language_model
+    if lm.args.tie_word_embeddings:
+        return lm.model.embed_tokens.as_linear(hidden)
+    return _unwrapped_head(model)(hidden)
+
+
+class MTPHead(nn.Module):
+    """The native single-layer MTP head shipped inside Qwen3.8.
+
+    Shared vocabulary modules are deliberately installed with
+    ``object.__setattr__``.  They remain reachable for forward calls but are not
+    registered as MTP parameters, so evaluating or serializing the head
+    does not walk the 2.5 GB embedding/head twice.
+    """
+
+    def __init__(self, config: dict, target) -> None:
+        super().__init__()
+        from mlx_lm.models import qwen3_5 as qwen
+
+        text_config = config.get("text_config", config)
+        args = qwen.TextModelArgs.from_dict(text_config)
+        if text_config.get("mtp_num_hidden_layers", 1) != 1:
+            raise ValueError("escha-mlx currently supports exactly one MTP layer")
+        if text_config.get("mtp_use_dedicated_embeddings", False):
+            raise ValueError("dedicated MTP embeddings are not supported")
+
+        # Layer zero becomes full attention when the interval is one.  Building
+        # the layer directly avoids allocating a temporary vocab-sized Qwen
+        # model only to replace its embedding and head.
+        args = dataclasses.replace(args, num_hidden_layers=1, full_attention_interval=1)
+        self.pre_fc_norm_embedding = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.pre_fc_norm_hidden = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.fc = nn.Linear(2 * args.hidden_size, args.hidden_size, bias=False)
+        self.layers = [qwen.DecoderLayer(args, 0)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+        object.__setattr__(self, "_embed_tokens", target.language_model.model.embed_tokens)
+        object.__setattr__(self, "_lm_head", _unwrapped_head(target))
+        self.hidden_size = args.hidden_size
+
+    def make_cache(self):
+        from mlx_lm.models.cache import KVCache
+
+        return [KVCache()]
+
+    def forward_hidden(
+        self,
+        input_ids: mx.array,
+        target_hidden: mx.array,
+        cache=None,
+    ) -> mx.array:
+        """Advance the MTP layer and return its hidden states, before the head."""
+        from mlx_lm.models.base import create_attention_mask
+
+        if input_ids.ndim != 2 or target_hidden.ndim != 3:
+            raise ValueError("MTP expects input_ids [B,S] and target_hidden [B,S,H]")
+        if input_ids.shape[:2] != target_hidden.shape[:2]:
+            raise ValueError(
+                f"MTP token/hidden shape mismatch: {input_ids.shape} vs "
+                f"{target_hidden.shape}"
+            )
+        if target_hidden.shape[-1] != self.hidden_size:
+            raise ValueError(
+                f"MTP hidden size {target_hidden.shape[-1]} != {self.hidden_size}"
+            )
+
+        embedding = self.pre_fc_norm_embedding(self._embed_tokens(input_ids))
+        hidden = self.pre_fc_norm_hidden(target_hidden)
+        hidden = self.fc(mx.concatenate([embedding, hidden], axis=-1))
+        layer_cache = None if cache is None else cache[0]
+        mask = create_attention_mask(hidden, layer_cache)
+        hidden = self.layers[0](hidden, mask=mask, cache=layer_cache)
+        return self.norm(hidden)
+
+    def forward_tree_hidden(
+        self,
+        input_ids: mx.array,
+        target_hidden: mx.array,
+        cache,
+        parents: mx.array,
+        depths: mx.array,
+        *,
+        start: int,
+        prefix: int,
+        base_positions: mx.array,
+        left_padding: list[int],
+    ) -> mx.array:
+        """Advance one topological proposal level on a shared MTP KV prefix."""
+        embedding = self.pre_fc_norm_embedding(self._embed_tokens(input_ids))
+        hidden = self.pre_fc_norm_hidden(target_hidden)
+        hidden = self.fc(mx.concatenate([embedding, hidden], axis=-1))
+        layer = self.layers[0]
+        normed = layer.input_layernorm(hidden)
+        mask = _incremental_tree_mask(
+            parents, start, prefix, left_padding
+        )
+        positions = base_positions + depths[:, start:] - 1
+        residual = _tree_attention(
+            layer.self_attn, normed, mask, cache[0], positions
+        )
+        post_attention = hidden + residual
+        hidden = post_attention + layer.mlp(
+            layer.post_attention_layernorm(post_attention)
+        )
+        return self.norm(hidden)
+
+    def logits(self, hidden: mx.array) -> mx.array:
+        return self._lm_head(hidden)
+
+    def __call__(self, input_ids, target_hidden, cache=None):
+        return self.logits(self.forward_hidden(input_ids, target_hidden, cache))
+
+
+def load_mtp(path: str | Path, target) -> MTPHead:
+    """Load ``path/mtp`` and share the target model's vocabulary modules."""
+    from safetensors import safe_open
+
+    from .loader import resolve_module
+
+    mtp_dir = Path(path) / "mtp"
+    config_path = mtp_dir / "config.json"
+    weights_path = mtp_dir / "model.safetensors"
+    if not config_path.exists() or not weights_path.exists():
+        raise FileNotFoundError(
+            f"MTP requested but {mtp_dir} is incomplete; expected config.json and "
+            "model.safetensors"
+        )
+
+    config = json.loads(config_path.read_text())
+    mtp_head = MTPHead(config, target)
+    parameters = dict(tree_flatten(mtp_head.parameters()))
+    expected = set(parameters)
+    loaded: set[str] = set()
+
+    with safe_open(str(weights_path), framework="numpy") as f:
+        for checkpoint_name in f.keys():
+            if not checkpoint_name.startswith("mtp."):
+                raise ValueError(f"unexpected non-MTP tensor {checkpoint_name!r}")
+            name = checkpoint_name[len("mtp.") :]
+            if name not in expected:
+                raise ValueError(f"unexpected MTP tensor {checkpoint_name!r}")
+            weight = f.get_tensor(checkpoint_name)
+            wanted_shape = tuple(parameters[name].shape)
+            if tuple(weight.shape) != wanted_shape:
+                raise ValueError(
+                    f"{checkpoint_name}: shape {weight.shape}, expected {wanted_shape}"
+                )
+            # Qwen3.5 exports Gemma-style RMSNorm deltas; MLX nn.RMSNorm stores
+            # the effective multiplicative weight.
+            if name in _NORM_WEIGHTS:
+                weight = (weight.astype("float32") + 1.0).astype(weight.dtype)
+            owner, attr = resolve_module(mtp_head, name)
+            setattr(owner, attr, mx.array(weight))
+            loaded.add(name)
+
+    missing = expected - loaded
+    if missing:
+        raise ValueError(f"incomplete MTP checkpoint, missing {sorted(missing)}")
+
+    mtp_head.eval()
+    mx.eval(mtp_head.parameters())
+    logger.info("escha_mlx: loaded Qwen3.8 native MTP head (%d tensors)", len(loaded))
+    return mtp_head
+
+
+@dataclasses.dataclass
+class _CacheMark:
+    """Attention-cache offsets before tree verification."""
+
+    offsets: list[int | None]
+
+
+def _mark_cache(cache: Iterable) -> _CacheMark:
+    return _CacheMark([getattr(item, "offset", None) for item in cache])
+
+
+def _sample_rows(logits: mx.array, sampler: Callable | None):
+    logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    if sampler is None:
+        tokens = mx.argmax(logprobs, axis=-1)
+    else:
+        tokens = sampler(logprobs)
+    return tokens.reshape(-1), logprobs
+
+
+def _target_forward(model, token_ids: mx.array, cache):
+    hidden = model.language_model.model(token_ids, cache=cache)
+    return hidden, _target_logits(model, hidden)
+
+
+def _target_hidden(model, token_ids: mx.array, cache):
+    """Target body only; avoids a vocab projection during prefill/replay."""
+    return model.language_model.model(token_ids, cache=cache)
+
+
+def _eval_initialized_cache(cache) -> None:
+    """Evaluate cache arrays without passing an unallocated KV state to MLX."""
+    states = []
+    for item in cache:
+        if getattr(item, "keys", None) is None:
+            continue
+        state = item.state
+        if all(value is not None for value in state):
+            states.append(state)
+    if states:
+        mx.eval(states)
+
+
+def _topk_log_probs_ops(logits: mx.array, topk: int):
+    log_probs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    indices = mx.argpartition(-log_probs, kth=topk - 1, axis=-1)[..., :topk]
+    scores = mx.take_along_axis(log_probs, indices, axis=-1)
+    return scores, indices.astype(mx.uint32)
+
+
+def _topk_log_probs(logits: mx.array, topk: int):
+    from .mtp_topk import metal_topk_log_probs
+
+    accelerated = metal_topk_log_probs(logits, topk=topk)
+    return (
+        accelerated
+        if accelerated is not None
+        else _topk_log_probs_ops(logits, topk)
+    )
+
+
+@dataclasses.dataclass
+class _TreeProposal:
+    tokens: mx.array       # [1, selected draft nodes]
+    parents: mx.array      # [1, root + selected nodes], root parent == -1
+    depths: mx.array       # [1, root + selected nodes]
+
+
+def _propose_tree(
+    mtp_head: MTPHead,
+    seed_hidden: mx.array,
+    seed_logits: mx.array,
+    committed_cache,
+    spec: _TreeSpec = _DEFAULT_TREE_SPEC,
+) -> _TreeProposal:
+    """Build the fixed topk-3/depth-3 lattice and select three draft nodes.
+
+    Proposal levels are appended temporarily to the committed MTP cache with a
+    tree mask, so all branches share one physical KV prefix. All 3 + 9 + 9 path
+    candidates are ranked by cumulative log probability; taking the best nodes
+    automatically retains ancestors because every child score is no greater
+    than its parent's score.
+    """
+    topk, depth, num_draft_nodes = spec.topk, spec.depth, spec.draft_nodes
+
+    batch = seed_logits.shape[0]
+    scores, tokens = _topk_log_probs(seed_logits, topk)
+    all_scores = [scores]
+    all_tokens = [tokens]
+    all_parents = [mx.full((batch, topk), -1, dtype=mx.int32)]
+    all_depths = [mx.ones((batch, topk), dtype=mx.int32)]
+    item = committed_cache[0]
+    if hasattr(item, "_idx"):
+        prefix = item._idx
+        base_positions = item.offset[:, None]
+        left_padding = item.left_padding
+    else:
+        prefix = item.offset
+        base_positions = mx.full((batch, 1), item.offset, dtype=mx.int32)
+        left_padding = [0] * batch
+
+    appended = 0
+    try:
+        if depth > 1:
+            frontier_scores = scores
+            frontier_tokens = tokens
+            frontier_nodes = mx.broadcast_to(
+                mx.arange(topk, dtype=mx.int32), (batch, topk)
+            )
+            frontier_cache_nodes = frontier_nodes
+            processed_parents = all_parents[0]
+            processed_depths = all_depths[0]
+            seed_rows = mx.broadcast_to(
+                seed_hidden[:, -1:, :], (batch, topk, seed_hidden.shape[-1])
+            )
+            frontier_hidden = mtp_head.forward_tree_hidden(
+                frontier_tokens,
+                seed_rows,
+                committed_cache,
+                processed_parents,
+                processed_depths,
+                start=0,
+                prefix=prefix,
+                base_positions=base_positions,
+                left_padding=left_padding,
+            )
+            appended += topk
+            candidate_base = topk
+
+            for level in range(1, depth):
+                next_logits = mtp_head.logits(frontier_hidden)
+                child_log_probs, child_tokens = _topk_log_probs(next_logits, topk)
+                path_scores = frontier_scores[:, :, None] + child_log_probs
+                flat_scores = path_scores.reshape(batch, topk * topk)
+                flat_tokens = child_tokens.reshape(batch, topk * topk)
+                parents = mx.repeat(frontier_nodes, topk, axis=1)
+                depths = mx.full(
+                    (batch, topk * topk), level + 1, dtype=mx.int32
+                )
+                all_scores.append(flat_scores)
+                all_tokens.append(flat_tokens)
+                all_parents.append(parents)
+                all_depths.append(depths)
+
+                if level + 1 < depth:
+                    chosen = mx.argpartition(
+                        -flat_scores, kth=topk - 1, axis=-1
+                    )[:, :topk]
+                    parent_rows = chosen // topk
+                    frontier_scores = mx.take_along_axis(
+                        flat_scores, chosen, axis=1
+                    )
+                    frontier_tokens = mx.take_along_axis(
+                        flat_tokens, chosen, axis=1
+                    )
+                    hidden_index = parent_rows[:, :, None]
+                    hidden_index = mx.broadcast_to(
+                        hidden_index,
+                        (batch, topk, frontier_hidden.shape[-1]),
+                    )
+                    parent_hidden = mx.take_along_axis(
+                        frontier_hidden, hidden_index, axis=1
+                    )
+                    cache_parents = mx.take_along_axis(
+                        frontier_cache_nodes, parent_rows, axis=1
+                    )
+                    start = appended
+                    processed_parents = mx.concatenate(
+                        [processed_parents, cache_parents], axis=1
+                    )
+                    processed_depths = mx.concatenate(
+                        [
+                            processed_depths,
+                            mx.full(
+                                (batch, topk), level + 1, dtype=mx.int32
+                            ),
+                        ],
+                        axis=1,
+                    )
+                    frontier_hidden = mtp_head.forward_tree_hidden(
+                        frontier_tokens,
+                        parent_hidden,
+                        committed_cache,
+                        processed_parents,
+                        processed_depths,
+                        start=start,
+                        prefix=prefix,
+                        base_positions=base_positions,
+                        left_padding=left_padding,
+                    )
+                    frontier_cache_nodes = mx.broadcast_to(
+                        start + mx.arange(topk, dtype=mx.int32),
+                        (batch, topk),
+                    )
+                    frontier_nodes = candidate_base + chosen.astype(mx.int32)
+                    appended += topk
+                candidate_base += topk * topk
+
+        candidate_scores = mx.concatenate(all_scores, axis=1)
+        candidate_tokens = mx.concatenate(all_tokens, axis=1)
+        candidate_parents = mx.concatenate(all_parents, axis=1)
+        candidate_depths = mx.concatenate(all_depths, axis=1)
+        count = num_draft_nodes
+        selected = mx.argpartition(
+            -candidate_scores, kth=count - 1, axis=-1
+        )[:, :count]
+        # Candidate order is depth-major. Restoring that order makes every parent
+        # precede its children, which both tree kernels rely on.
+        selected = mx.sort(selected, axis=-1)
+        selected_tokens = mx.take_along_axis(candidate_tokens, selected, axis=1)
+        selected_parents = mx.take_along_axis(candidate_parents, selected, axis=1)
+        selected_depths = mx.take_along_axis(candidate_depths, selected, axis=1)
+
+        # Map parents from candidate-lattice coordinates into the compact tree
+        # without synchronizing selected indices back to Python. Depth-major
+        # ordering plus non-increasing cumulative log probability guarantees
+        # that every selected child's parent is also selected.
+        parent_matches = selected_parents[:, :, None] == selected[:, None, :]
+        compact_parents = mx.argmax(
+            parent_matches.astype(mx.int32), axis=-1
+        ).astype(mx.int32) + 1
+        compact_parents = mx.where(selected_parents < 0, 0, compact_parents)
+        tree_parents = mx.concatenate(
+            [mx.full((batch, 1), -1, dtype=mx.int32), compact_parents], axis=1
+        )
+        tree_depths = mx.concatenate(
+            [mx.zeros((batch, 1), dtype=mx.int32), selected_depths], axis=1
+        )
+        # Cache trimming below changes Python offsets, not the arrays captured
+        # by this graph. Schedule the proposal first so later MTP-cache writes
+        # remain ordered behind it without making the CPU wait here.
+        mx.async_eval(selected_tokens, tree_parents, tree_depths)
+    finally:
+        if appended:
+            for cache_item in committed_cache:
+                cache_item.trim(appended)
+
+    return _TreeProposal(
+        tokens=selected_tokens.astype(mx.uint32),
+        parents=tree_parents,
+        depths=tree_depths,
+    )
+
+
+def _accepted_tree_paths(verify_ids, target_tokens, parents):
+    """Materialize and follow the independently accepted path for each row."""
+    node_rows = verify_ids.tolist()
+    target_rows = target_tokens.tolist()
+    parent_rows = parents if isinstance(parents, list) else parents.tolist()
+    chains = []
+    for nodes, targets, tree in zip(node_rows, target_rows, parent_rows):
+        chain = [0]
+        while True:
+            parent = chain[-1]
+            child = next(
+                (
+                    node
+                    for node in range(1, len(tree))
+                    if tree[node] == parent and nodes[node] == targets[parent]
+                ),
+                None,
+            )
+            if child is None:
+                break
+            chain.append(child)
+        chains.append(chain)
+    return node_rows, target_rows, parent_rows, chains
+
+
+def _rope_at_positions(rope, x: mx.array, positions: mx.array) -> mx.array:
+    """Apply MLX's standard RoPE convention at arbitrary tree positions."""
+    dims = rope.dims
+    base = rope.base
+    scale = rope.scale
+    dtype = x.dtype
+    half = dims // 2
+    freq = base ** (mx.arange(half, dtype=mx.float32) * (2.0 / dims))
+    theta = positions[:, None, :, None].astype(mx.float32) * scale / freq
+    cos, sin = mx.cos(theta), mx.sin(theta)
+    rotated = x[..., :dims].astype(mx.float32)
+    if rope.traditional:
+        even, odd = rotated[..., ::2], rotated[..., 1::2]
+        pair = mx.stack([even * cos - odd * sin, even * sin + odd * cos], axis=-1)
+        rotated = pair.reshape(*rotated.shape)
+    else:
+        first, second = rotated[..., :half], rotated[..., half:]
+        rotated = mx.concatenate(
+            [first * cos - second * sin, first * sin + second * cos], axis=-1
+        )
+    return mx.concatenate([rotated.astype(dtype), x[..., dims:]], axis=-1)
+
+
+def _tree_attention(attention, x, mask, cache, positions):
+    """Qwen3.5 full attention with per-node RoPE positions and tree mask."""
+    from mlx_lm.models.base import scaled_dot_product_attention
+
+    B, L, _ = x.shape
+    q_out = attention.q_proj(x)
+    queries, gate = mx.split(
+        q_out.reshape(B, L, attention.num_attention_heads, -1), 2, axis=-1
+    )
+    gate = gate.reshape(B, L, -1)
+    if hasattr(attention, "inner"):
+        from .dense import project_pair
+
+        keys, values = project_pair(attention.k_proj, attention.v_proj, x)
+    else:
+        keys, values = attention.k_proj(x), attention.v_proj(x)
+    queries = attention.q_norm(queries).transpose(0, 2, 1, 3)
+    keys = attention.k_norm(
+        keys.reshape(B, L, attention.num_key_value_heads, -1)
+    ).transpose(0, 2, 1, 3)
+    values = values.reshape(B, L, attention.num_key_value_heads, -1).transpose(
+        0, 2, 1, 3
+    )
+    queries = _rope_at_positions(attention.rope, queries, positions)
+    keys = _rope_at_positions(attention.rope, keys, positions)
+    keys, values = cache.update_and_fetch(keys, values)
+    output = scaled_dot_product_attention(
+        queries, keys, values, cache=cache, scale=attention.scale, mask=mask
+    )
+    output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+    return attention.o_proj(output * mx.sigmoid(gate))
+
+
+def _tree_ancestry(parents: mx.array) -> mx.array:
+    """Return ``[B, node, ancestor]`` visibility without a CPU round-trip."""
+    batch, width = parents.shape
+    ancestors = mx.arange(width, dtype=mx.int32)[None, None, :]
+    current = mx.broadcast_to(
+        mx.arange(width, dtype=mx.int32)[None, :], (batch, width)
+    )
+    visible = mx.zeros((batch, width, width), dtype=mx.bool_)
+    # Parent indices are topological, so width hops is a finite upper bound for
+    # every valid tree. The loop builds a lazy MLX graph; it does not read data.
+    for _ in range(width):
+        valid = current >= 0
+        visible = visible | (valid[:, :, None] & (current[:, :, None] == ancestors))
+        safe = mx.maximum(current, 0)
+        parent = mx.take_along_axis(parents, safe, axis=1)
+        current = mx.where(valid, parent, -1)
+    return visible
+
+
+def _tree_mask_rows(
+    parents: mx.array,
+    start: int,
+    prefix: int,
+    left_padding,
+) -> mx.array:
+    """Join prefix padding and tree ancestry for query rows ``start:``."""
+    batch, width = parents.shape
+    query_rows = width - start
+    padding = mx.array(left_padding, dtype=mx.int32).reshape(batch, 1, 1)
+    prefix_visible = mx.arange(prefix, dtype=mx.int32)[None, None, :] >= padding
+    prefix_visible = mx.broadcast_to(
+        prefix_visible, (batch, query_rows, prefix)
+    )
+    ancestry = _tree_ancestry(parents)[:, start:, :]
+    return mx.concatenate([prefix_visible, ancestry], axis=-1)[:, None]
+
+
+def _incremental_tree_mask(
+    parents: mx.array,
+    start: int,
+    prefix: int,
+    left_padding,
+) -> mx.array:
+    """Mask one newly appended proposal level against a shared KV prefix."""
+    return _tree_mask_rows(parents, start, prefix, left_padding)
+
+
+def _tree_mask(parents: mx.array, prefix: int, left_padding) -> mx.array:
+    return _tree_mask_rows(parents, 0, prefix, left_padding)
+
+
+def _target_tree_forward(model, token_ids, parents, depths, cache):
+    """Verify a batch of equal-width trees in a single target-body pass."""
+    from . import gdn_cache
+
+    text_model = model.language_model.model
+    attention_cache = next(item for item in cache if item.is_trimmable())
+    if hasattr(attention_cache, "_idx"):
+        prefix = attention_cache._idx
+        base_positions = attention_cache.offset[:, None]
+        left_padding = attention_cache.left_padding
+    else:
+        prefix = int(attention_cache.offset)
+        base_positions = mx.full((token_ids.shape[0], 1), prefix, dtype=mx.int32)
+        left_padding = [0] * token_ids.shape[0]
+    positions = depths + base_positions
+    attention_mask = _tree_mask(parents, prefix, left_padding)
+    hidden = text_model.embed_tokens(token_ids)
+    trace = []
+    for layer, layer_cache in zip(text_model.layers, cache):
+        normed = layer.input_layernorm(hidden)
+        if layer.is_linear:
+            residual, layer_trace = gdn_cache.trace_gdn_forward(
+                layer.linear_attn,
+                normed,
+                cache=layer_cache,
+                tree_parents=parents,
+            )
+            trace.append(layer_trace)
+        else:
+            residual = _tree_attention(
+                layer.self_attn, normed, attention_mask, layer_cache, positions
+            )
+        post_attention = hidden + residual
+        hidden = post_attention + layer.mlp(
+            layer.post_attention_layernorm(post_attention)
+        )
+    hidden = text_model.norm(hidden)
+    return hidden, _target_logits(model, hidden), trace
+
+
+def _commit_tree_cache(cache, mark: _CacheMark, chain: list[int], trace) -> None:
+    """Compact selected attention nodes and commit matching recurrent states."""
+    from . import gdn_cache
+
+    selected = []
+    chain_array = mx.array(chain)
+    for index, item in enumerate(cache):
+        if not item.is_trimmable():
+            continue
+        prefix = mark.offsets[index]
+        candidate_width = item.offset - prefix
+        candidate_keys = item.keys[..., prefix : prefix + candidate_width, :]
+        candidate_values = item.values[..., prefix : prefix + candidate_width, :]
+        selected_keys = mx.take(candidate_keys, chain_array, axis=2)
+        selected_values = mx.take(candidate_values, chain_array, axis=2)
+        selected.append((item, prefix, selected_keys, selected_values))
+    # Evaluate every gather before any overlapping in-place cache write. One
+    # synchronization covers all full-attention layers instead of one per layer.
+    if selected:
+        mx.eval([(keys, values) for _, _, keys, values in selected])
+    for item, prefix, selected_keys, selected_values in selected:
+        item.keys[..., prefix : prefix + len(chain), :] = selected_keys
+        item.values[..., prefix : prefix + len(chain), :] = selected_values
+        item.offset = prefix + len(chain)
+    gdn_cache.commit_tree_states(trace, [chain[-1]])
+
+
+def mtp_generate_step(
+    prompt: mx.array,
+    model,
+    *,
+    mtp_head: MTPHead | None = None,
+    max_tokens: int = 256,
+    sampler: Callable | None = None,
+    prefill_step_size: int = 256,
+) -> Generator[tuple[int, mx.array, bool], None, None]:
+    """Generate with the measured topk-3/depth-3/M=4 MTP proposal tree."""
+    if max_tokens <= 0:
+        return
+    if prompt.ndim != 1 or prompt.size == 0:
+        raise ValueError("prompt must be a non-empty one-dimensional token array")
+    if prefill_step_size < 1:
+        raise ValueError("prefill_step_size must be at least one")
+
+    mtp_head = mtp_head or getattr(model, "mtp", None)
+    if mtp_head is None:
+        raise ValueError("model has no native MTP head; load it with load_mtp=True")
+
+    target_cache = model.make_cache()
+    mtp_cache = mtp_head.make_cache()
+    prompt = prompt.astype(mx.uint32)
+    prompt_len = int(prompt.size)
+
+    # Target prefill covers the full prompt.  MTP prefill is shifted by one:
+    # H(x_t) is paired with embedding(x_{t+1}).  The final H is retained and
+    # paired with the first target-generated token below.
+    final_target_hidden = None
+    for start in range(0, prompt_len, prefill_step_size):
+        end = min(start + prefill_step_size, prompt_len)
+        target_hidden = _target_hidden(model, prompt[start:end][None], target_cache)
+        usable = min(end, prompt_len - 1) - start
+        if usable > 0:
+            mtp_head.forward_hidden(
+                prompt[start + 1 : start + 1 + usable][None],
+                target_hidden[:, :usable],
+                mtp_cache,
+            )
+        final_target_hidden = target_hidden[:, -1:]
+        mx.eval(final_target_hidden, [c.state for c in target_cache])
+        _eval_initialized_cache(mtp_cache)
+
+    first_logits = _target_logits(model, final_target_hidden)[:, -1, :]
+    first, first_logprobs = _sample_rows(first_logits, sampler)
+    mx.eval(first, first_logprobs)
+    current = first.astype(mx.uint32)
+
+    if max_tokens == 1:
+        yield int(current.item()), first_logprobs[0], False
+        return
+
+    # Processing the verified token once gives the first proposal and keeps the
+    # MTP cache one token ahead of the target cache, as in SGLang's MTP path.
+    mtp_hidden = mtp_head.forward_hidden(current[None], final_target_hidden, mtp_cache)
+    mtp_logits = mtp_head.logits(mtp_hidden)[:, -1, :]
+    mx.eval(mtp_hidden, mtp_logits, [c.state for c in mtp_cache])
+
+    produced = 1
+    yield int(current.item()), first_logprobs[0], False
+
+    while produced < max_tokens:
+        remaining = max_tokens - produced
+        if remaining > 1:
+            tree = _propose_tree(
+                mtp_head,
+                mtp_hidden,
+                mtp_logits,
+                mtp_cache,
+            )
+            verify_ids = mx.concatenate([current[None], tree.tokens], axis=1)
+            target_mark = _mark_cache(target_cache)
+            verify_hidden, verify_logits, gdn_trace = _target_tree_forward(
+                model, verify_ids, tree.parents, tree.depths, target_cache
+            )
+            target_tokens, target_logprobs = _sample_rows(
+                verify_logits[0], sampler
+            )
+            mx.eval(
+                verify_hidden,
+                target_tokens,
+                target_logprobs,
+                [item.state for item in target_cache],
+            )
+
+            node_rows, target_rows, _, chains = _accepted_tree_paths(
+                verify_ids, target_tokens[None], tree.parents
+            )
+            node_tokens = node_rows[0]
+            target_ids = target_rows[0]
+            chain = chains[0]
+
+            n_recurrent = sum(
+                not item.is_trimmable() for item in target_cache
+            )
+            if len(gdn_trace) != n_recurrent:
+                raise RuntimeError("incomplete GDN trace during tree verification")
+            _commit_tree_cache(target_cache, target_mark, chain, gdn_trace)
+
+            accepted_ids = [node_tokens[node] for node in chain[1:]]
+            last_node = chain[-1]
+            new_current_id = target_ids[last_node]
+            new_current = mx.array([new_current_id], dtype=mx.uint32)
+
+            replay_ids = mx.array(
+                accepted_ids + [new_current_id], dtype=mx.uint32
+            )[None]
+            replay_hidden = mx.take(
+                verify_hidden, mx.array(chain, dtype=mx.int32), axis=1
+            )
+            mtp_hidden = mtp_head.forward_hidden(
+                replay_ids, replay_hidden, mtp_cache
+            )[:, -1:]
+            mtp_logits = mtp_head.logits(mtp_hidden)[:, -1, :]
+            mx.eval(mtp_hidden, mtp_logits, [item.state for item in mtp_cache])
+
+            for child_index, token_id in enumerate(accepted_ids):
+                if produced >= max_tokens:
+                    return
+                produced += 1
+                parent_node = chain[child_index]
+                yield token_id, target_logprobs[parent_node], True
+            if produced >= max_tokens:
+                return
+            produced += 1
+            yield new_current_id, target_logprobs[last_node], False
+            current = new_current
+            continue
+
+        # Only one output remains. Process the pending current token once to
+        # obtain the final target token; building a speculative tree cannot
+        # reduce the number of target calls at this boundary.
+        verify_hidden, verify_logits = _target_forward(
+            model, current[None], target_cache
+        )
+        target_tokens, target_logprobs = _sample_rows(verify_logits[0], sampler)
+        mx.eval(
+            verify_hidden,
+            target_tokens,
+            target_logprobs,
+            [item.state for item in target_cache],
+        )
+        yield int(target_tokens[0].item()), target_logprobs[0], False
+        return
+
+
+def stream_generate(
+    model,
+    tokenizer,
+    prompt,
+    *,
+    max_tokens: int = 256,
+    mtp_head: MTPHead | None = None,
+    **kwargs,
+):
+    """Streaming text wrapper matching ``mlx_lm.generate.stream_generate``."""
+    from mlx_lm.generate import GenerationResponse, generation_stream, wired_limit
+    from mlx_lm.tokenizer_utils import TokenizerWrapper
+
+    if not isinstance(tokenizer, TokenizerWrapper):
+        tokenizer = TokenizerWrapper(tokenizer)
+    if not isinstance(prompt, mx.array):
+        if isinstance(prompt, str):
+            add_special = tokenizer.bos_token is None or not prompt.startswith(
+                tokenizer.bos_token
+            )
+            prompt = tokenizer.encode(prompt, add_special_tokens=add_special)
+        prompt = mx.array(prompt)
+
+    detokenizer = tokenizer.detokenizer
+    step = mtp_generate_step(
+        prompt, model, mtp_head=mtp_head, max_tokens=max_tokens, **kwargs
+    )
+    with wired_limit(model, [generation_stream]):
+        started = time.perf_counter()
+        for index, (token, logprobs, from_draft) in enumerate(step):
+            if index == 0:
+                prompt_time = time.perf_counter() - started
+                prompt_tps = prompt.size / prompt_time
+                decode_started = time.perf_counter()
+            stop = token in tokenizer.eos_token_ids
+            if not stop:
+                detokenizer.add_token(token)
+            final = stop or index + 1 == max_tokens
+            if not final:
+                yield GenerationResponse(
+                    text=detokenizer.last_segment,
+                    token=token,
+                    logprobs=logprobs,
+                    from_draft=from_draft,
+                    prompt_tokens=prompt.size,
+                    prompt_tps=prompt_tps,
+                    generation_tokens=index + 1,
+                    generation_tps=(index + 1) / (time.perf_counter() - decode_started),
+                    peak_memory=mx.get_peak_memory() / 1e9,
+                    finish_reason=None,
+                )
+                continue
+
+            detokenizer.finalize()
+            yield GenerationResponse(
+                text=detokenizer.last_segment,
+                token=token,
+                logprobs=logprobs,
+                from_draft=from_draft,
+                prompt_tokens=prompt.size,
+                prompt_tps=prompt_tps,
+                generation_tokens=index + 1,
+                generation_tps=(index + 1) / (time.perf_counter() - decode_started),
+                peak_memory=mx.get_peak_memory() / 1e9,
+                finish_reason="stop" if stop else "length",
+            )
+            return

--- a/escha_mlx/mtp_batch.py
+++ b/escha_mlx/mtp_batch.py
@@ -1,0 +1,842 @@
+"""Continuous batching adapter for the native Qwen3.8 MTP head.
+
+Each request accepts its own linear prefix or path through the topk=3/depth=3
+proposal tree. BatchKVCache remains physically rectangular by right-aligning
+the independently committed histories; GDN/conv state is selected from each
+request's own final verification node. No request is shortened to the minimum
+acceptance of its peers.
+"""
+from __future__ import annotations
+
+import copy
+from typing import Callable, List
+
+import mlx.core as mx
+
+from mlx_lm.generate import (
+    BatchResponse,
+    BatchGenerator as _BatchGenerator,
+    GenerationBatch as _GenerationBatch,
+    PromptProcessingBatch as _PromptProcessingBatch,
+    _make_cache,
+)
+from mlx_lm.models.cache import BatchKVCache, BatchRotatingKVCache
+
+from .mtp import (
+    _accepted_tree_paths,
+    _propose_tree,
+    _target_forward,
+    _target_hidden,
+    _target_tree_forward,
+)
+
+
+def _right_pad(rows: List[List[int]], width: int) -> mx.array:
+    return mx.array([row + [0] * (width - len(row)) for row in rows])
+
+
+def _reject_rotating_cache(cache) -> None:
+    """Fail before tree verification reaches a cache layout it cannot commit."""
+    if any(isinstance(item, BatchRotatingKVCache) for item in cache):
+        raise ValueError(
+            "native MTP does not support rotating KV caches; omit max_kv_size"
+        )
+
+
+def _batch_path_marks(cache):
+    """Remember the rectangular attention boundary before verification."""
+    return [
+        (
+            item._idx,
+            mx.array(item.offset.tolist()),
+            mx.array(item.left_padding.tolist()),
+        )
+        if item.is_trimmable()
+        else None
+        for item in cache
+    ]
+
+
+def _commit_batch_paths(cache, marks, chains, trace):
+    """Right-align independently selected verification paths in BatchKVCache."""
+    from . import gdn_cache
+
+    lengths = [len(chain) for chain in chains]
+    max_length = max(lengths)
+    padding = [max_length - length for length in lengths]
+    B = len(chains)
+    for item, mark in zip(cache, marks):
+        if not item.is_trimmable():
+            continue
+        prefix, old_offset, old_left_padding = mark
+        key_rows, value_rows = [], []
+        for b, (chain, pad) in enumerate(zip(chains, padding)):
+            old_keys = item.keys[b : b + 1, :, :prefix, :]
+            old_values = item.values[b : b + 1, :, :prefix, :]
+            tree_keys = mx.take(
+                item.keys[b : b + 1, :, prefix : item._idx, :],
+                mx.array(chain, dtype=mx.int32),
+                axis=2,
+            )
+            tree_values = mx.take(
+                item.values[b : b + 1, :, prefix : item._idx, :],
+                mx.array(chain, dtype=mx.int32),
+                axis=2,
+            )
+            key_pad = mx.zeros(
+                (1, old_keys.shape[1], pad, old_keys.shape[3]),
+                dtype=old_keys.dtype,
+            )
+            value_pad = mx.zeros(
+                (1, old_values.shape[1], pad, old_values.shape[3]),
+                dtype=old_values.dtype,
+            )
+            key_rows.append(mx.concatenate([key_pad, old_keys, tree_keys], axis=2))
+            value_rows.append(
+                mx.concatenate([value_pad, old_values, tree_values], axis=2)
+            )
+        item.keys = mx.concatenate(key_rows, axis=0)
+        item.values = mx.concatenate(value_rows, axis=0)
+        item._idx = prefix + max_length
+        item.offset = old_offset + mx.array(lengths)
+        item.left_padding = old_left_padding + mx.array(padding)
+    gdn_cache.commit_tree_states(trace, [chain[-1] for chain in chains])
+
+
+def _right_pad_hidden(rows):
+    width = max(row.shape[1] for row in rows)
+    padded = [
+        mx.pad(row, [(0, 0), (0, width - row.shape[1]), (0, 0)])
+        for row in rows
+    ]
+    return mx.concatenate(padded, axis=0), width
+
+
+class MTPGenerationBatch(_GenerationBatch):
+    """A real batched MTP decode stage compatible with mlx-lm's scheduler."""
+
+    def __init__(
+        self,
+        *args,
+        mtp_prefill_step_size: int = 256,
+        mtp_cache=None,
+        **kwargs,
+    ):
+        self.mtp_prefill_step_size = mtp_prefill_step_size
+        model = args[0] if args else kwargs.get("model")
+        self.mtp_head = getattr(model, "mtp", None)
+        if self.mtp_head is None:
+            raise ValueError("batched MTP requires a model loaded with load_mtp=True")
+        self.mtp_cache = mtp_cache or []
+        self._mtp_hidden = None
+        self._mtp_logits = None
+        self._mtp_bootstrapped = False
+        self._last_target_trace = []
+        self._last_target_chains = []
+        super().__init__(*args, **kwargs)
+
+    @classmethod
+    def empty(
+        cls,
+        model,
+        fallback_sampler: Callable,
+        *,
+        mtp_prefill_step_size: int = 256,
+    ):
+        return cls(
+            model=model,
+            fallback_sampler=fallback_sampler,
+            uids=[],
+            inputs=mx.array([], dtype=mx.uint32),
+            prompt_cache=[],
+            tokens=[],
+            samplers=[],
+            logits_processors=[],
+            max_tokens=[],
+            state_machines=[],
+            mtp_prefill_step_size=mtp_prefill_step_size,
+        )
+
+    def _sample(self, logits: mx.array, prefixes: mx.array, tree_parents=None):
+        """Apply each request's processors/sampler at every proposed position."""
+        B, T, _ = logits.shape
+        if not any(self.logits_processors) and not any(self.samplers):
+            logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+            samples = self.fallback_sampler(logprobs.reshape(-1, logits.shape[-1]))
+            return samples.reshape(B, T), logprobs
+
+        sample_rows, logprob_rows = [], []
+        for b in range(B):
+            row_samples, row_logprobs = [], []
+            sampler = self.samplers[b] or self.fallback_sampler
+            for t in range(T):
+                row_logits = logits[b : b + 1, t]
+                if self.logits_processors[b]:
+                    if tree_parents is not None:
+                        path, node = [], t
+                        parents = tree_parents[b]
+                        while node >= 0:
+                            path.append(node)
+                            node = parents[node]
+                        suffix = mx.take(
+                            prefixes[b], mx.array(path[::-1], dtype=mx.int32)
+                        )
+                    else:
+                        suffix = prefixes[b, : t + 1]
+                    context = mx.concatenate(
+                        [self._token_context[b].tokens, suffix]
+                    )
+                    for processor in self.logits_processors[b]:
+                        row_logits = processor(context, row_logits)
+                row_logprobs_t = row_logits - mx.logsumexp(
+                    row_logits, axis=-1, keepdims=True
+                )
+                row_samples.append(sampler(row_logprobs_t).reshape(()))
+                row_logprobs.append(row_logprobs_t[0])
+            sample_rows.append(mx.stack(row_samples))
+            logprob_rows.append(mx.stack(row_logprobs))
+        return mx.stack(sample_rows), mx.stack(logprob_rows)
+
+    def _prefill_mtp_head(self, last_prompt_tokens: mx.array) -> None:
+        """Build the head cache from target prompt hiddens, including cache hits.
+
+        mlx-lm's prompt cache currently stores target states only.  Replaying the
+        target body here keeps that public cache format unchanged and makes MTP
+        work for both fresh and cached prompts.  The replay is chunked and its
+        cache is released immediately after the head has consumed the hiddens.
+        """
+        last = last_prompt_tokens.tolist()
+        prompts = [list(tokens) + [token] for tokens, token in zip(self.tokens, last)]
+        target_rows = [prompt[:-1] for prompt in prompts]
+        mtp_rows = [prompt[1:] for prompt in prompts]
+        lengths = [len(row) for row in target_rows]
+        width = max(lengths, default=0)
+        B = len(prompts)
+
+        self.mtp_cache = [BatchKVCache([0] * B)]
+        if width == 0:
+            return
+
+        padding = [width - length for length in lengths]
+        target_ids = _right_pad(target_rows, width)
+        mtp_ids = _right_pad(mtp_rows, width)
+        scratch_cache = _make_cache(self.model, [0] * B, None)
+        for item in scratch_cache:
+            item.prepare(lengths=lengths, right_padding=padding)
+        for item in self.mtp_cache:
+            item.prepare(lengths=lengths, right_padding=padding)
+
+        step = self.mtp_prefill_step_size
+        for start in range(0, width, step):
+            end = min(start + step, width)
+            hidden = _target_hidden(
+                self.model, target_ids[:, start:end], scratch_cache
+            )
+            self.mtp_head.forward_hidden(
+                mtp_ids[:, start:end], hidden, self.mtp_cache
+            )
+            mx.eval(
+                [item.state for item in scratch_cache],
+                [item.state for item in self.mtp_cache],
+            )
+            mx.clear_cache()
+
+        for item in self.mtp_cache:
+            item.finalize()
+        mx.eval([item.state for item in self.mtp_cache])
+
+    def _bootstrap(self):
+        """Consume the last prompt token and seed the first MTP proposal."""
+        self._current_tokens = self._next_tokens
+        self._current_logprobs = self._next_logprobs
+        inputs = self._current_tokens
+        if not self.mtp_cache:
+            self._prefill_mtp_head(inputs)
+
+        hidden, logits = _target_forward(self.model, inputs[:, None], self.prompt_cache)
+        sampled, logprobs = self._sample(logits[:, -1:, :], inputs[:, None])
+        sampled = sampled[:, 0].astype(mx.uint32)
+        self._next_tokens = sampled
+        self._next_logprobs = list(logprobs[:, 0])
+
+        self._mtp_hidden = self.mtp_head.forward_hidden(
+            sampled[:, None], hidden[:, -1:], self.mtp_cache
+        )[:, -1:]
+        self._mtp_logits = self.mtp_head.logits(self._mtp_hidden)[:, -1, :]
+        mx.async_eval(
+            self._next_tokens,
+            self._next_logprobs,
+            self._mtp_hidden,
+            self._mtp_logits,
+            [item.state for item in self.mtp_cache],
+        )
+
+        mx.eval(inputs, self._current_logprobs)
+        for stored, token in zip(self.tokens, inputs.tolist()):
+            stored.append(token)
+        for context, token in zip(self._token_context, inputs):
+            context.update_and_fetch(token[None])
+        self._mtp_bootstrapped = True
+        return inputs.tolist(), self._current_logprobs
+
+    def _replay_mtp_rows(self, token_rows, hidden_rows):
+        """Rebuild independently accepted MTP suffixes in one padded batch."""
+        lengths = [len(row) for row in token_rows]
+        width = max(lengths)
+        replay_ids = _right_pad(token_rows, width).astype(mx.uint32)
+        replay_hidden, hidden_width = _right_pad_hidden(hidden_rows)
+        if hidden_width != width:
+            raise RuntimeError("MTP replay token/hidden widths diverged")
+        padding = [width - length for length in lengths]
+        for item in self.mtp_cache:
+            item.prepare(lengths=lengths, right_padding=padding)
+        all_hidden = self.mtp_head.forward_hidden(
+            replay_ids, replay_hidden, self.mtp_cache
+        )
+        last_hidden = mx.stack(
+            [all_hidden[b, length - 1] for b, length in enumerate(lengths)]
+        )[:, None]
+        for item in self.mtp_cache:
+            item.finalize()
+        self._mtp_hidden = last_hidden
+        self._mtp_logits = self.mtp_head.logits(last_hidden)[:, -1, :]
+
+    def _step(self):
+        if not self._mtp_bootstrapped:
+            return self._bootstrap()
+
+        # The previous trace is needed only while ``next()`` turns its accepted
+        # burst into responses (notably to extract an exact cache at an early
+        # stop).  Release it before building the next verification graph.  A
+        # GDN trace is several times the recurrent-cache size because it keeps
+        # every tree node; retaining two rounds at once pushes an MTP B=8 server
+        # over the Metal working-set limit when the prompt LRU is populated.
+        self._last_target_trace = []
+        self._last_target_chains = []
+        self._current_tokens = self._next_tokens
+        self._current_logprobs = self._next_logprobs
+        current = self._current_tokens.astype(mx.uint32)
+        remaining = [
+            limit - used for limit, used in zip(self.max_tokens, self._num_tokens)
+        ]
+        if max(remaining) > 1:
+            return self._tree_step(current)
+
+        # Every request has exactly one pending token left. Commit those tokens
+        # to the target cache without paying for an unused vocabulary head or
+        # another proposal tree.
+        hidden = _target_hidden(self.model, current[:, None], self.prompt_cache)
+        mx.eval(hidden, [item.state for item in self.prompt_cache])
+        return (
+            [[token] for token in current.tolist()],
+            [[logprobs] for logprobs in self._current_logprobs],
+        )
+
+    def _tree_step(self, current):
+        """One fixed topk-3/depth-3/M=4 proposal round for the batch."""
+        tree = _propose_tree(
+            self.mtp_head,
+            self._mtp_hidden,
+            self._mtp_logits,
+            self.mtp_cache,
+        )
+        verify_ids = mx.concatenate([current[:, None], tree.tokens], axis=1)
+        marks = _batch_path_marks(self.prompt_cache)
+        verify_hidden, verify_logits, target_trace = _target_tree_forward(
+            self.model, verify_ids, tree.parents, tree.depths, self.prompt_cache
+        )
+        needs_tree_paths = any(self.logits_processors) or any(self.samplers)
+        parent_rows = tree.parents.tolist() if needs_tree_paths else None
+        target_tokens, target_logprobs = self._sample(
+            verify_logits, verify_ids, parent_rows
+        )
+        mx.eval(
+            verify_hidden,
+            target_tokens,
+            target_logprobs,
+            [item.state for item in self.prompt_cache],
+        )
+
+        verify_rows, target_rows, parent_rows, chains = _accepted_tree_paths(
+            verify_ids,
+            target_tokens,
+            parent_rows if parent_rows is not None else tree.parents,
+        )
+
+        recurrent = [item for item in self.prompt_cache if not item.is_trimmable()]
+        if len(target_trace) != len(recurrent):
+            raise RuntimeError("incomplete GDN trace during batched tree verification")
+        _commit_batch_paths(self.prompt_cache, marks, chains, target_trace)
+        self._last_target_trace = target_trace
+        self._last_target_chains = chains
+
+        replay_token_rows, replay_hidden_rows = [], []
+        next_tokens, next_logprobs = [], []
+        token_rows, logprob_rows = [], []
+        for b, chain in enumerate(chains):
+            accepted = [verify_rows[b][node] for node in chain[1:]]
+            last_node = chain[-1]
+            next_token = target_rows[b][last_node]
+            replay_token_rows.append(accepted + [next_token])
+            replay_hidden_rows.append(mx.take(
+                verify_hidden[b : b + 1], mx.array(chain, dtype=mx.int32), axis=1
+            ))
+            next_tokens.append(next_token)
+            next_logprobs.append(target_logprobs[b, last_node])
+            token_rows.append([int(current[b].item()), *accepted])
+            logprob_rows.append(
+                [self._current_logprobs[b]]
+                + [target_logprobs[b, parent] for parent in chain[:-1]]
+            )
+
+        self._replay_mtp_rows(replay_token_rows, replay_hidden_rows)
+        self._next_tokens = mx.array(next_tokens, dtype=mx.uint32)
+        self._next_logprobs = next_logprobs
+        mx.async_eval(
+            self._next_tokens,
+            self._next_logprobs,
+            self._mtp_hidden,
+            self._mtp_logits,
+            [item.state for item in self.mtp_cache],
+        )
+        return token_rows, logprob_rows
+
+    def _finished_target_cache(self, batch_idx: int, position: int, width: int):
+        """Extract a cache ending at an early stop inside an accepted burst."""
+        extracted = self.extract_cache(batch_idx)
+        extra = width - position - 1
+        if extra == 0:
+            return extracted
+
+        trace_idx = 0
+        trace_position = (
+            self._last_target_chains[batch_idx][position]
+            if self._last_target_chains
+            else position
+        )
+        for source, destination in zip(self.prompt_cache, extracted):
+            if source.is_trimmable():
+                destination.trim(extra)
+                continue
+            trace_cache, conv_states, recurrent_states = self._last_target_trace[
+                trace_idx
+            ]
+            if trace_cache is not source:
+                raise RuntimeError("GDN trace/cache order changed during extraction")
+            destination.state = [
+                conv_states[batch_idx : batch_idx + 1, trace_position],
+                recurrent_states[batch_idx : batch_idx + 1, trace_position],
+            ]
+            trace_idx += 1
+        return extracted
+
+    def next(self):
+        if not self.uids:
+            return []
+
+        token_rows, logprob_rows = self._step()
+        responses = []
+        keep = []
+        for batch_idx in range(len(self.uids)):
+            width = len(token_rows[batch_idx])
+            finished = False
+            for position, (token, logprobs) in enumerate(
+                zip(token_rows[batch_idx], logprob_rows[batch_idx])
+            ):
+                self.tokens[batch_idx].append(token)
+                self._token_context[batch_idx].update_and_fetch(
+                    mx.array([token], dtype=mx.int32)
+                )
+                self._num_tokens[batch_idx] += 1
+                finish_reason = None
+                if self._num_tokens[batch_idx] >= self.max_tokens[batch_idx]:
+                    finish_reason = "length"
+                (
+                    self._matcher_states[batch_idx],
+                    match_sequence,
+                    current_state,
+                ) = self.state_machines[batch_idx].match(
+                    self._matcher_states[batch_idx], token
+                )
+                if match_sequence is not None and current_state is None:
+                    finish_reason = "stop"
+
+                if finish_reason is not None:
+                    responses.append(
+                        self.Response(
+                            uid=self.uids[batch_idx],
+                            token=token,
+                            logprobs=logprobs,
+                            finish_reason=finish_reason,
+                            current_state=current_state,
+                            match_sequence=match_sequence,
+                            prompt_cache=self._finished_target_cache(
+                                batch_idx, position, width
+                            ),
+                            all_tokens=self.tokens[batch_idx],
+                        )
+                    )
+                    finished = True
+                    break
+
+                responses.append(
+                    self.Response(
+                        uid=self.uids[batch_idx],
+                        token=token,
+                        logprobs=logprobs,
+                        finish_reason=None,
+                        current_state=current_state,
+                        match_sequence=match_sequence,
+                        prompt_cache=None,
+                        all_tokens=None,
+                    )
+                )
+            if not finished:
+                keep.append(batch_idx)
+
+        if len(keep) < len(self.uids):
+            self.filter(keep)
+        return responses
+
+    def filter(self, keep):
+        super().filter(keep)
+        if keep:
+            for item in self.mtp_cache:
+                item.filter(keep)
+            self._mtp_hidden = self._mtp_hidden[keep]
+            self._mtp_logits = self._mtp_logits[keep]
+        else:
+            self.mtp_cache.clear()
+            self._mtp_hidden = None
+            self._mtp_logits = None
+
+    def extend(self, batch):
+        was_empty = not self.uids
+        super().extend(batch)
+        if was_empty:
+            self.mtp_cache = batch.mtp_cache
+            self._mtp_hidden = batch._mtp_hidden
+            self._mtp_logits = batch._mtp_logits
+            self._mtp_bootstrapped = batch._mtp_bootstrapped
+        else:
+            for current, incoming in zip(self.mtp_cache, batch.mtp_cache):
+                current.extend(incoming)
+            self._mtp_hidden = mx.concatenate([self._mtp_hidden, batch._mtp_hidden])
+            self._mtp_logits = mx.concatenate([self._mtp_logits, batch._mtp_logits])
+
+
+class MTPPromptProcessingBatch(_PromptProcessingBatch):
+    """Prompt stage which hands completed requests to MTPGenerationBatch."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        _reject_rotating_cache(self.prompt_cache)
+        self.mtp_head = getattr(self.model, "mtp", None)
+        if self.mtp_head is None:
+            raise ValueError("batched MTP requires a model loaded with load_mtp=True")
+        self.mtp_cache = [BatchKVCache([0] * len(self.uids))]
+        self._mtp_pending_hidden = [None] * len(self.uids)
+        # Fresh requests can construct the shifted MTP cache while the target
+        # prompt is already being evaluated. Existing target-only prompt caches
+        # have no hidden-state sidecar, so those requests retain the replay
+        # fallback in MTPGenerationBatch._prefill_mtp_head.
+        target_has_history = any(
+            item.is_trimmable() and getattr(item, "_idx", 0) > 0
+            for item in self.prompt_cache
+        )
+        self._mtp_online_prefill = not target_has_history and not any(self.tokens)
+
+    def _append_mtp(self, token_rows, hidden_rows):
+        """Append independently sized shifted pairs to the batched MTP cache."""
+        lengths = [len(row) for row in token_rows]
+        width = max(lengths, default=0)
+        if width == 0:
+            return
+        padding = [width - length for length in lengths]
+        input_ids = _right_pad(token_rows, width).astype(mx.uint32)
+        hidden = mx.concatenate(
+            [
+                mx.pad(row, [(0, 0), (0, width - row.shape[1]), (0, 0)])
+                for row in hidden_rows
+            ],
+            axis=0,
+        )
+        for item in self.mtp_cache:
+            item.prepare(lengths=lengths, right_padding=padding)
+        self.mtp_head.forward_hidden(input_ids, hidden, self.mtp_cache)
+        mx.eval([item.state for item in self.mtp_cache])
+        if max(padding) > 0:
+            for item in self.mtp_cache:
+                item.finalize()
+            mx.eval([item.state for item in self.mtp_cache])
+
+    def _consume_target_hidden(self, token_rows, hidden, lengths):
+        """Pair target H(x_t) with x_(t+1), retaining the final unpaired H."""
+        pair_tokens, pair_hidden = [], []
+        for b, (row, length) in enumerate(zip(token_rows, lengths)):
+            row_hidden = hidden[b : b + 1, :length]
+            if length == 0:
+                pair_tokens.append([])
+                pair_hidden.append(row_hidden)
+                continue
+            pending = self._mtp_pending_hidden[b]
+            if pending is None:
+                pair_tokens.append(row[1:length])
+                pair_hidden.append(row_hidden[:, :-1])
+            else:
+                pair_tokens.append(row[:length])
+                pair_hidden.append(
+                    mx.concatenate([pending, row_hidden[:, :-1]], axis=1)
+                )
+            self._mtp_pending_hidden[b] = row_hidden[:, -1:]
+        self._append_mtp(pair_tokens, pair_hidden)
+
+    def prompt(self, tokens):
+        """Prefill target and native MTP caches in the same target-body pass."""
+        if len(self.uids) != len(tokens):
+            raise ValueError("The batch length doesn't match the number of inputs")
+        if not tokens:
+            return
+
+        token_rows = [list(row) for row in tokens]
+        for stored, row in zip(self.tokens, token_rows):
+            stored += row
+        lengths = [len(row) for row in token_rows]
+        max_length = max(lengths)
+        padding = [max_length - length for length in lengths]
+        if max(padding) > 0:
+            inputs = _right_pad(token_rows, max_length)
+            for item in self.prompt_cache:
+                item.prepare(lengths=lengths, right_padding=padding)
+        else:
+            inputs = mx.array(token_rows)
+
+        start = 0
+        while start < max_length:
+            width = min(self.prefill_step_size, max_length - start)
+            chunk_lengths = [max(0, min(length - start, width)) for length in lengths]
+            hidden = _target_hidden(
+                self.model, inputs[:, start : start + width], self.prompt_cache
+            )
+            chunk_rows = [
+                row[start : start + length]
+                for row, length in zip(token_rows, chunk_lengths)
+            ]
+            if self._mtp_online_prefill:
+                self._consume_target_hidden(chunk_rows, hidden, chunk_lengths)
+            mx.eval(hidden, [item.state for item in self.prompt_cache])
+            mx.clear_cache()
+            start += width
+
+        if max(padding) > 0:
+            for item in self.prompt_cache:
+                item.finalize()
+            mx.eval([item.state for item in self.prompt_cache])
+            mx.clear_cache()
+
+    @classmethod
+    def empty(
+        cls,
+        model,
+        fallback_sampler,
+        prefill_step_size: int = 2048,
+    ):
+        return cls(
+            model=model,
+            fallback_sampler=fallback_sampler,
+            prefill_step_size=prefill_step_size,
+            uids=[],
+            caches=[],
+            tokens=[],
+            samplers=[],
+            logits_processors=[],
+            max_tokens=[],
+            state_machines=[],
+        )
+
+    def _copy(self):
+        copied = super()._copy()
+        copied.mtp_head = self.mtp_head
+        copied.mtp_cache = copy.deepcopy(self.mtp_cache)
+        copied._mtp_pending_hidden = list(self._mtp_pending_hidden)
+        copied._mtp_online_prefill = self._mtp_online_prefill
+        return copied
+
+    def filter(self, keep):
+        if self._mtp_online_prefill:
+            if keep:
+                for item in self.mtp_cache:
+                    item.filter(keep)
+                self._mtp_pending_hidden = [
+                    self._mtp_pending_hidden[index] for index in keep
+                ]
+            else:
+                self.mtp_cache.clear()
+                self._mtp_pending_hidden = []
+        super().filter(keep)
+
+    def extend(self, batch):
+        online = self._mtp_online_prefill and batch._mtp_online_prefill
+        was_empty = not self.uids
+        if online:
+            if was_empty:
+                mtp_cache = batch.mtp_cache
+                pending = list(batch._mtp_pending_hidden)
+            else:
+                for current, incoming in zip(self.mtp_cache, batch.mtp_cache):
+                    current.extend(incoming)
+                mtp_cache = self.mtp_cache
+                pending = self._mtp_pending_hidden + batch._mtp_pending_hidden
+        super().extend(batch)
+        self._mtp_online_prefill = online
+        if online:
+            self.mtp_cache = mtp_cache
+            self._mtp_pending_hidden = pending
+        else:
+            self.mtp_cache = []
+            self._mtp_pending_hidden = []
+
+    def generate(self, tokens):
+        if any(len(row) > 1 for row in tokens):
+            self.prompt([row[:-1] for row in tokens])
+        last_token = mx.array([row[-1] for row in tokens])
+        mtp_cache = None
+        if self._mtp_online_prefill:
+            pair_tokens, pair_hidden = [], []
+            for token, pending in zip(last_token.tolist(), self._mtp_pending_hidden):
+                if pending is None:
+                    pair_tokens.append([])
+                    pair_hidden.append(
+                        mx.zeros((1, 0, self.mtp_head.hidden_size), dtype=mx.float16)
+                    )
+                else:
+                    pair_tokens.append([token])
+                    pair_hidden.append(pending)
+            self._append_mtp(pair_tokens, pair_hidden)
+            mtp_cache = self.mtp_cache
+        generation = MTPGenerationBatch(
+            self.model,
+            self.uids,
+            last_token,
+            self.prompt_cache,
+            self.tokens,
+            self.samplers,
+            self.fallback_sampler,
+            self.logits_processors,
+            self.state_machines,
+            self.max_tokens,
+            mtp_prefill_step_size=self.prefill_step_size,
+            mtp_cache=mtp_cache,
+        )
+        self.uids = []
+        self.prompt_cache = []
+        self.tokens = []
+        self.samplers = []
+        self.logits_processors = []
+        self.max_tokens = []
+        self.mtp_cache = []
+        self._mtp_pending_hidden = []
+        return generation
+
+
+class MTPBatchGenerator(_BatchGenerator):
+    """mlx-lm BatchGenerator with native MTP in its decode stage."""
+
+    def __init__(
+        self,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+        if self.max_kv_size is not None:
+            self.close()
+            raise ValueError(
+                "native MTP does not support max_kv_size; use a growing KV cache"
+            )
+        self._prompt_batch = MTPPromptProcessingBatch.empty(
+            self.model,
+            self.sampler,
+            prefill_step_size=self.prefill_step_size,
+        )
+        self._generation_batch = MTPGenerationBatch.empty(
+            self.model,
+            self.sampler,
+            mtp_prefill_step_size=self.prefill_step_size,
+        )
+
+    def _make_batch(self, n: int):
+        uids, caches, tokens = [], [], []
+        samplers, processors, max_tokens, state_machines = [], [], [], []
+        for _ in range(n):
+            sequence = self._unprocessed_sequences.popleft()
+            uids.append(sequence[0])
+            caches.append(sequence[3])
+            tokens.append(sequence[4])
+            samplers.append(sequence[5])
+            processors.append(sequence[6])
+            max_tokens.append(sequence[2])
+            state_machines.append(sequence[7])
+            self._currently_processing.append(
+                [sequence[1], 0, sum(len(segment) for segment in sequence[1])]
+            )
+        return MTPPromptProcessingBatch(
+            model=self.model,
+            uids=uids,
+            caches=caches,
+            tokens=tokens,
+            prefill_step_size=self.prefill_step_size,
+            samplers=samplers,
+            fallback_sampler=self.sampler,
+            logits_processors=processors,
+            state_machines=state_machines,
+            max_tokens=max_tokens,
+        )
+
+    @property
+    def prompt_cache_nbytes(self):
+        base = super().prompt_cache_nbytes
+        prompt_mtp = sum(item.nbytes for item in self._prompt_batch.mtp_cache)
+        generation_mtp = sum(
+            item.nbytes for item in self._generation_batch.mtp_cache
+        )
+        return base + prompt_mtp + generation_mtp
+
+
+def batch_generate(
+    model,
+    tokenizer,
+    prompts: List[List[int]],
+    *,
+    prompt_caches=None,
+    max_tokens=128,
+    return_prompt_caches: bool = False,
+    **kwargs,
+) -> BatchResponse:
+    """Generate a static batch through the same MTP path used by the server."""
+    generator = MTPBatchGenerator(
+        model,
+        stop_tokens=[[token] for token in tokenizer.eos_token_ids],
+        **kwargs,
+    )
+    if isinstance(max_tokens, int):
+        max_tokens = [max_tokens] * len(prompts)
+    uids = generator.insert(prompts, max_tokens, caches=prompt_caches)
+    output = {uid: [] for uid in uids}
+    output_caches = {}
+    with generator.stats() as stats:
+        while responses := generator.next_generated():
+            for response in responses:
+                if response.finish_reason != "stop":
+                    output[response.uid].append(response.token)
+                if response.finish_reason is not None and return_prompt_caches:
+                    output_caches[response.uid] = response.prompt_cache
+    generator.close()
+    texts = [tokenizer.decode(output[uid]) for uid in uids]
+    caches = (
+        [output_caches[uid] for uid in uids] if return_prompt_caches else None
+    )
+    return BatchResponse(texts, stats, caches)

--- a/escha_mlx/mtp_topk.py
+++ b/escha_mlx/mtp_topk.py
@@ -1,0 +1,251 @@
+"""Small-row top-k log probabilities for native-MTP tree proposals.
+
+The general MLX path materializes normalized logits and then runs a vocabulary-
+wide argpartition. Tree drafting only needs a few values and indices, so the
+Metal path reduces 2048-logit blocks and then merges their summaries. Its
+logsumexp association can differ by one f16 ulp from MLX; this is proposal-only
+scoring and every selected token is still verified by the target model.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+
+import mlx.core as mx
+
+
+_CHUNK = 2048
+_THREADS = 256
+_TOPK = 3
+_HEADER = "#include <metal_stdlib>\nusing namespace metal;\n"
+
+
+_PARTIAL_SOURCE = r"""
+    uint tid = thread_index_in_threadgroup;
+    uint lane = thread_index_in_simdgroup;
+    uint sg = simdgroup_index_in_threadgroup;
+    uint block = thread_position_in_grid.x >> 8;
+    uint row = thread_position_in_grid.y;
+    uint base = block * CHUNK;
+
+    float best[TOPK];
+    uint best_idx[TOPK];
+    for (uint j = 0; j < TOPK; ++j) {
+      best[j] = -INFINITY;
+      best_idx[j] = 0;
+    }
+    for (uint item = 0; item < ITEMS; ++item) {
+      uint index = base + tid + item * 256;
+      if (index >= N) continue;
+      float value = (float)logits[(ulong)row * N + index];
+      for (uint j = 0; j < TOPK; ++j) {
+        if (value > best[j]) {
+          for (uint shift = TOPK - 1; shift > j; --shift) {
+            best[shift] = best[shift - 1];
+            best_idx[shift] = best_idx[shift - 1];
+          }
+          best[j] = value;
+          best_idx[j] = index;
+          break;
+        }
+      }
+    }
+
+    threadgroup float candidates[256 * TOPK];
+    threadgroup uint candidate_indices[256 * TOPK];
+    for (uint j = 0; j < TOPK; ++j) {
+      candidates[tid * TOPK + j] = best[j];
+      candidate_indices[tid * TOPK + j] = best_idx[j];
+    }
+
+    // Keep the broadcast maximum and subgroup sums in separate storage.
+    // Reusing subgroup[0] lets SIMD group zero overwrite the maximum while
+    // another group is still reading it in the exp loop.
+    threadgroup float subgroup_max[8];
+    threadgroup float subgroup_sum[8];
+    float reduced_max = simd_max(best[0]);
+    if (lane == 0) subgroup_max[sg] = reduced_max;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid == 0) {
+      float group_max = subgroup_max[0];
+      for (uint j = 1; j < 8; ++j)
+        group_max = max(group_max, subgroup_max[j]);
+      part_max[(ulong)row * BLOCKS + block] = group_max;
+      subgroup_max[0] = group_max;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    float sum = 0.0f;
+    for (uint item = 0; item < ITEMS; ++item) {
+      uint index = base + tid + item * 256;
+      if (index < N)
+        sum += exp((float)logits[(ulong)row * N + index] - subgroup_max[0]);
+    }
+    sum = simd_sum(sum);
+    if (lane == 0) subgroup_sum[sg] = sum;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (tid == 0) {
+      float group_sum = 0.0f;
+      for (uint j = 0; j < 8; ++j) group_sum += subgroup_sum[j];
+      ulong out = ((ulong)row * BLOCKS + block) * TOPK;
+      float group_best[TOPK];
+      uint group_idx[TOPK];
+      for (uint j = 0; j < TOPK; ++j) {
+        group_best[j] = -INFINITY;
+        group_idx[j] = 0;
+      }
+      for (uint candidate = 0; candidate < 256 * TOPK; ++candidate) {
+        float value = candidates[candidate];
+        uint index = candidate_indices[candidate];
+        for (uint j = 0; j < TOPK; ++j) {
+          if (value > group_best[j]) {
+            for (uint shift = TOPK - 1; shift > j; --shift) {
+              group_best[shift] = group_best[shift - 1];
+              group_idx[shift] = group_idx[shift - 1];
+            }
+            group_best[j] = value;
+            group_idx[j] = index;
+            break;
+          }
+        }
+      }
+      for (uint j = 0; j < TOPK; ++j) {
+        part_values[out + j] = group_best[j];
+        part_indices[out + j] = group_idx[j];
+      }
+      part_sum[(ulong)row * BLOCKS + block] = group_sum;
+    }
+"""
+
+
+_FINAL_SOURCE = r"""
+    uint tid = thread_index_in_threadgroup;
+    uint lane = thread_index_in_simdgroup;
+    uint sg = simdgroup_index_in_threadgroup;
+    uint row = thread_position_in_grid.y;
+
+    float block_max = tid < BLOCKS
+        ? part_max[(ulong)row * BLOCKS + tid] : -INFINITY;
+    float reduced_max = simd_max(block_max);
+    threadgroup float subgroup_max[8];
+    threadgroup float subgroup_sum[8];
+    if (lane == 0) subgroup_max[sg] = reduced_max;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (tid == 0) {
+      float global_max = subgroup_max[0];
+      for (uint j = 1; j < 8; ++j)
+        global_max = max(global_max, subgroup_max[j]);
+      subgroup_max[0] = global_max;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    float global_max = subgroup_max[0];
+
+    float adjusted = tid < BLOCKS
+        ? part_sum[(ulong)row * BLOCKS + tid] * exp(block_max - global_max)
+        : 0.0f;
+    adjusted = simd_sum(adjusted);
+    if (lane == 0) subgroup_sum[sg] = adjusted;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (tid == 0) {
+      float total = 0.0f;
+      for (uint j = 0; j < 8; ++j) total += subgroup_sum[j];
+      float log_norm = global_max + log(total);
+      float best[TOPK];
+      uint best_idx[TOPK];
+      for (uint j = 0; j < TOPK; ++j) {
+        best[j] = -INFINITY;
+        best_idx[j] = 0;
+      }
+      ulong base = (ulong)row * BLOCKS * TOPK;
+      for (uint candidate = 0; candidate < BLOCKS * TOPK; ++candidate) {
+        float value = part_values[base + candidate];
+        uint index = part_indices[base + candidate];
+        for (uint j = 0; j < TOPK; ++j) {
+          if (value > best[j]) {
+            for (uint shift = TOPK - 1; shift > j; --shift) {
+              best[shift] = best[shift - 1];
+              best_idx[shift] = best_idx[shift - 1];
+            }
+            best[j] = value;
+            best_idx[j] = index;
+            break;
+          }
+        }
+      }
+      for (uint j = 0; j < TOPK; ++j) {
+        scores[(ulong)row * TOPK + j] = (half)(best[j] - log_norm);
+        indices[(ulong)row * TOPK + j] = best_idx[j];
+      }
+    }
+"""
+
+
+@lru_cache(maxsize=1)
+def _partial_kernel():
+    return mx.fast.metal_kernel(
+        name="escha_mtp_topk_partial_k3",
+        input_names=["logits"],
+        output_names=["part_values", "part_indices", "part_max", "part_sum"],
+        header=_HEADER,
+        source=_PARTIAL_SOURCE,
+    )
+
+
+@lru_cache(maxsize=1)
+def _final_kernel():
+    return mx.fast.metal_kernel(
+        name="escha_mtp_topk_final_k3",
+        input_names=["part_values", "part_indices", "part_max", "part_sum"],
+        output_names=["scores", "indices"],
+        header=_HEADER,
+        source=_FINAL_SOURCE,
+    )
+
+
+def metal_topk_log_probs(logits: mx.array, *, topk: int = _TOPK):
+    """Return top-3 normalized scores/indices, or `None` for MLX fallback."""
+    if (
+        topk != _TOPK
+        or logits.ndim < 2
+        or not mx.metal.is_available()
+        or mx.default_device() != mx.gpu
+        or logits.dtype != mx.float16
+        or logits.shape[-1] < _CHUNK
+    ):
+        return None
+
+    shape = logits.shape
+    vocab = shape[-1]
+    rows = 1
+    for dimension in shape[:-1]:
+        rows *= dimension
+    blocks = (vocab + _CHUNK - 1) // _CHUNK
+    if blocks > _THREADS:
+        return None
+    flat = logits.reshape(rows, vocab)
+    partial = _partial_kernel()(
+        inputs=[flat],
+        template=[
+            ("InT", logits.dtype), ("N", vocab), ("TOPK", _TOPK),
+            ("CHUNK", _CHUNK), ("ITEMS", _CHUNK // _THREADS),
+            ("BLOCKS", blocks),
+        ],
+        grid=(_THREADS * blocks, rows, 1),
+        threadgroup=(_THREADS, 1, 1),
+        output_shapes=[
+            (rows, blocks, _TOPK), (rows, blocks, _TOPK),
+            (rows, blocks), (rows, blocks),
+        ],
+        output_dtypes=[mx.float32, mx.uint32, mx.float32, mx.float32],
+    )
+    scores, indices = _final_kernel()(
+        inputs=list(partial),
+        template=[("TOPK", _TOPK), ("BLOCKS", blocks)],
+        grid=(_THREADS, rows, 1),
+        threadgroup=(_THREADS, 1, 1),
+        output_shapes=[(rows, _TOPK), (rows, _TOPK)],
+        output_dtypes=[mx.float16, mx.uint32],
+    )
+    output_shape = (*shape[:-1], _TOPK)
+    return scores.reshape(output_shape), indices.reshape(output_shape)

--- a/escha_mlx/quant.py
+++ b/escha_mlx/quant.py
@@ -34,10 +34,17 @@ the 1 byte/weight payload, at group 128 it is 6.25%.  Across the 2.16 GB of Q8
 streams this model reads per token that is a ~120 MB/token saving for provably
 zero numerical change -- the largest free win in the byte ledger.  128 is
 MLX's maximum affine group size, hence the default.
+
+The vocabulary projection has a Metal specialization for one to eight flattened
+rows. One simdgroup reduces one output channel and reuses its Q8 weight row for
+all inputs, which is the target-verification shape used by native MTP. Larger
+batches and non-Metal backends keep MLX's general quantized matmul. The
+specialization is enabled by default; ESCHA_MLX_Q8_HEAD=0 selects the fallback.
 """
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -53,6 +60,9 @@ _VALIDATED: set[int] = set()
 _GROUPS = (128, 64, 32)
 
 DEFAULT_GROUP = envs.DEFAULT_Q8_GROUP
+
+_Q8_HEAD_MAX_ROWS = 8
+_METAL_HEADER = "#include <metal_stdlib>\nusing namespace metal;\n"
 
 
 def fit_group(k: int, requested: int = DEFAULT_GROUP) -> int:
@@ -133,6 +143,113 @@ class EschaQ8Linear(nn.Module):
         return y.astype(x.dtype)
 
 
+def _q8_head_source(rows: int) -> str:
+    """One simdgroup reduces one vocabulary row for ``rows`` inputs."""
+    accumulators = "\n".join(
+        f"    float acc{row} = 0.0f;" for row in range(rows)
+    )
+    products = "\n".join(
+        f"        acc{row} += dot(float4(*((device const half4*)(x + "
+        f"(ulong){row} * K) + packed)), weights);"
+        for row in range(rows)
+    )
+    reductions = "\n".join(
+        f"        acc{row} += simd_shuffle_down(acc{row}, delta);"
+        for row in range(rows)
+    )
+    stores = "\n".join(
+        f"        out[(ulong){row} * N + column] = (half)(acc{row} * scale);"
+        for row in range(rows)
+    )
+    return f"""
+    uint lane = thread_index_in_simdgroup;
+    uint column = thread_position_in_grid.x >> 5;
+    if (column >= (uint)N) return;
+{accumulators}
+    // pack_q8 repeats the export's per-output-channel scale in every affine
+    // group. Read its first copy and apply it once after the dot-product.
+    float scale = scales[(ulong)column * GROUPS];
+    device const uint* weight_row = weight + (ulong)column * PACKED_K;
+    for (uint packed = lane; packed < PACKED_K; packed += 32u) {{
+        uint q = weight_row[packed];
+        float4 weights = float4(
+            (float)(q & 255u) - 128.0f,
+            (float)((q >> 8) & 255u) - 128.0f,
+            (float)((q >> 16) & 255u) - 128.0f,
+            (float)((q >> 24) & 255u) - 128.0f
+        );
+{products}
+    }}
+    for (uint delta = 16u; delta > 0u; delta >>= 1) {{
+{reductions}
+    }}
+    if (lane == 0u) {{
+{stores}
+    }}
+"""
+
+
+@lru_cache(maxsize=None)
+def _q8_head_kernel(rows: int):
+    return mx.fast.metal_kernel(
+        name=f"escha_q8_head_r{rows}",
+        input_names=["x", "weight", "scales"],
+        output_names=["out"],
+        header=_METAL_HEADER,
+        source=_q8_head_source(rows),
+    )
+
+
+def q8_head(
+    x: mx.array,
+    weight: mx.array,
+    scales: mx.array,
+    group_size: int,
+) -> mx.array:
+    """Project 1..8 flattened rows through a repacked Q8 vocabulary matrix."""
+    k = x.shape[-1]
+    rows = 1
+    for dimension in x.shape[:-1]:
+        rows *= dimension
+    if not 1 <= rows <= _Q8_HEAD_MAX_ROWS:
+        raise ValueError(
+            f"q8_head supports 1..{_Q8_HEAD_MAX_ROWS} rows, got {rows}"
+        )
+    n = weight.shape[0]
+    kernel = _q8_head_kernel(rows)
+    (out,) = kernel(
+        inputs=[x.reshape(rows, k), weight.reshape(-1), scales.reshape(-1)],
+        template=[
+            ("K", k),
+            ("PACKED_K", k // 4),
+            ("N", n),
+            ("GROUPS", k // group_size),
+        ],
+        grid=(256 * ((n + 7) // 8), 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(rows, n)],
+        output_dtypes=[mx.float16],
+    )
+    return out.reshape(*x.shape[:-1], n)
+
+
+class EschaQ8Head(EschaQ8Linear):
+    """Q8 vocabulary head with a measured small-row Metal specialization."""
+
+    def __call__(self, x: mx.array) -> mx.array:
+        rows = 1
+        for dimension in x.shape[:-1]:
+            rows *= dimension
+        if (
+            envs.ESCHA_MLX_Q8_HEAD.get()
+            and mx.metal.is_available()
+            and x.dtype == mx.float16
+            and 1 <= rows <= _Q8_HEAD_MAX_ROWS
+        ):
+            return q8_head(x, self.weight, self.scales, self._group_size)
+        return super().__call__(x)
+
+
 class EschaQ8Embedding(nn.Module):
     def __init__(self, packed: np.ndarray, scales: np.ndarray, biases: np.ndarray,
                  group_size: int, dtype=mx.float16) -> None:
@@ -160,6 +277,22 @@ def make_linear(w8: np.ndarray, scale: np.ndarray,
     g = fit_group(k, group_size)
     validate_pack(g)
     return EschaQ8Linear(*pack_q8(w8, scale, g), g)
+
+
+def make_head(w8: np.ndarray, scale: np.ndarray,
+              group_size: int = DEFAULT_GROUP) -> nn.Module:
+    """Build a vocabulary projection with the small-row Metal fast path."""
+    n, k = w8.shape
+    if dense_mode() == "fp16":
+        lin = nn.Linear(k, n, bias=False)
+        lin.weight = mx.array(
+            (w8.astype(np.float32) * scale.astype(np.float32)[:, None])
+            .astype(np.float16)
+        )
+        return lin
+    g = fit_group(k, group_size)
+    validate_pack(g)
+    return EschaQ8Head(*pack_q8(w8, scale, g), g)
 
 
 def make_embedding(w8: np.ndarray, scale: np.ndarray,

--- a/escha_mlx/server.py
+++ b/escha_mlx/server.py
@@ -2,8 +2,8 @@
 
 Thin wrapper over mlx_lm.server (continuous batching via BatchGenerator, prefix
 caching via LRUPromptCache, reasoning-content parsing, tool calls): routes model
-loading through escha_mlx.loader for escha checkpoints, delegates everything
-else verbatim.
+loading through escha_mlx.loader for escha checkpoints. Qwen3.8's native MTP
+head can be enabled without disabling continuous batching.
 
 Adds one serving extension: ``"ignore_eos": true`` in the request body, which
 suppresses end-of-sequence stopping so a request generates exactly max_tokens.
@@ -24,6 +24,64 @@ import sys
 # through mlx-lm's (model_key, stop_words, state) state-machine cache key, so
 # ignore_eos and normal requests never share a cached stop machine.
 _IGNORE_EOS_SENTINEL = "\x00escha_ignore_eos\x00"
+_MTP_DEFAULT_PROMPT_CACHE_BYTES = 512_000_000
+
+
+def _consume_mtp_args(argv):
+    """Remove the escha-only MTP switch before mlx-lm parses its arguments."""
+    enabled = False
+    cleaned = [argv[0]]
+    for arg in argv[1:]:
+        if arg == "--mtp":
+            enabled = True
+        else:
+            cleaned.append(arg)
+    return cleaned, enabled
+
+
+def _append_default_option(argv, option: str, value: str) -> bool:
+    """Append a server default unless either argparse spelling is present."""
+    if any(arg == option or arg.startswith(option + "=") for arg in argv[1:]):
+        return False
+    argv.extend([option, value])
+    return True
+
+
+def _install_mtp_prompt_cache_limit(server_mod, argv) -> int:
+    """Apply a byte cap to mlx-lm's count-bounded prompt LRU.
+
+    A B=8 MTP verification keeps a large GDN state trace.  Ten ordinary
+    Qwen3.8 prompt entries add about 0.9 GB and can push a 24 GB machine over
+    Metal's recommended working set, where failures surface as unrelated lazy
+    graph errors.  mlx-lm's ``--prompt-cache-bytes`` trims against active batch
+    caches, but its LRU constructor only receives the entry-count limit.  Apply
+    the same byte limit at insertion time as well so completed requests cannot
+    temporarily exceed the budget.
+    """
+    option = "--prompt-cache-bytes"
+    raw = None
+    for index, arg in enumerate(argv[1:], start=1):
+        if arg.startswith(option + "="):
+            raw = arg.split("=", 1)[1]
+            break
+        if arg == option:
+            if index + 1 >= len(argv):
+                raise ValueError(f"{option} requires a value")
+            raw = argv[index + 1]
+            break
+    if raw is None:
+        budget = _MTP_DEFAULT_PROMPT_CACHE_BYTES
+        argv.extend([option, str(budget)])
+    else:
+        budget = server_mod._parse_size(raw)
+
+    original = server_mod.LRUPromptCache
+
+    def bounded_prompt_cache(max_size):
+        return original(max_size=max_size, max_bytes=budget)
+
+    server_mod.LRUPromptCache = bounded_prompt_cache
+    return budget
 
 
 class _NoEosTokenizer:
@@ -75,6 +133,8 @@ def _install_ignore_eos(server_mod) -> None:
 
 
 def main() -> None:
+    argv, mtp_enabled = _consume_mtp_args(sys.argv)
+    sys.argv[:] = argv
     from mlx_lm import server as _server
 
     from .loader import is_escha_checkpoint, load as escha_load
@@ -85,10 +145,30 @@ def main() -> None:
         if is_escha_checkpoint(path):
             if kw.get("adapter_path"):
                 raise ValueError("escha_mlx: adapters are not supported")
-            return escha_load(path, tokenizer_config=kw.get("tokenizer_config"))
+            return escha_load(
+                path,
+                tokenizer_config=kw.get("tokenizer_config"),
+                load_mtp=mtp_enabled,
+            )
         return _orig_load(path, *a, **kw)
 
     _server.load = _load
+    if mtp_enabled:
+        if any(
+            arg == "--draft-model" or arg.startswith("--draft-model=")
+            for arg in sys.argv
+        ):
+            raise ValueError("--mtp cannot be combined with an external --draft-model")
+        # Tree verification wins at B=1/2 but loses to ordinary batched AR from
+        # B=4 onward, and its GDN traces scale linearly with the active batch.
+        # Keep the opt-in server safe and fast by default; explicit CLI values
+        # still win on machines where the user has measured another policy.
+        _append_default_option(sys.argv, "--decode-concurrency", "2")
+        _append_default_option(sys.argv, "--prompt-concurrency", "2")
+        _install_mtp_prompt_cache_limit(_server, sys.argv)
+        from .mtp_batch import MTPBatchGenerator
+
+        _server.BatchGenerator = MTPBatchGenerator
     _install_ignore_eos(_server)
     sys.argv[0] = "escha_mlx.server"
     _server.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,9 @@ classifiers = [
 ]
 dependencies = [
     "mlx>=0.32.0,<0.40",
-    "mlx-lm>=0.31.3",
+    # Native MTP subclasses the 0.31 batch scheduler; widen only with its
+    # compatibility tests in the same change.
+    "mlx-lm>=0.31.3,<0.32",
     "numpy>=2.0",
     "safetensors>=0.4",
 ]

--- a/tests/test_dense_checkpoint.py
+++ b/tests/test_dense_checkpoint.py
@@ -183,7 +183,7 @@ def test_truncated_real_load(monkeypatch):
     from escha_mlx import models
     from escha_mlx.dense import EschaLinear
     from escha_mlx.loader import LastPositionHead
-    from escha_mlx.quant import EschaQ8Embedding, EschaQ8Linear
+    from escha_mlx.quant import EschaQ8Embedding, EschaQ8Head
 
     monkeypatch.setenv("ESCHA_MLX_LINEAR", "ops")
     monkeypatch.setenv("ESCHA_MLX_BIAS", "1")   # exercise the correction path
@@ -229,7 +229,7 @@ def test_truncated_real_load(monkeypatch):
 
     assert isinstance(model.language_model.model.embed_tokens, EschaQ8Embedding)
     head = model.language_model.lm_head
-    assert isinstance(head, LastPositionHead) and isinstance(head.inner, EschaQ8Linear)
+    assert isinstance(head, LastPositionHead) and isinstance(head.inner, EschaQ8Head)
 
     # mlx-lm's (1+w) norm shift must have fired: HF stores these centred on 0.
     # Reduce in f32 — a 5120-wide f16 sum loses the tail entirely.

--- a/tests/test_dense_linear.py
+++ b/tests/test_dense_linear.py
@@ -433,6 +433,37 @@ def test_row_blocked_gemm_matches_per_row_gemv(K, m, R):
 
 
 @needs_metal
+@pytest.mark.parametrize("K", [2, 3])
+@pytest.mark.parametrize("m,R", [(2, 2), (3, 2), (4, 4), (5, 4)])
+@pytest.mark.parametrize("use_lut", [False, True])
+def test_direct_row_blocked_gemm_matches_per_row_gemv(
+    K, m, R, use_lut, monkeypatch
+):
+    """The barrier-free small-row path preserves every per-row sum bit."""
+    import mlx.core as mx
+    from escha_mlx import msl
+
+    monkeypatch.setenv("ESCHA_MLX_LUT", str(int(use_lut)))
+    rng = np.random.default_rng(450 + K + m)
+    ic, oc = BIG_IC, BIG_OC
+    code = mx.array(
+        msl.code_to_u32(
+            rng.integers(
+                -32768,
+                32768,
+                size=(ic // 16, oc // 16, 16 * K),
+                dtype=np.int16,
+            )
+        )
+    )
+    xh = mx.array((rng.standard_normal((m, ic)) * 0.3).astype(np.float16))
+    want = msl.dense_gemv(xh, code, K, ic, oc)
+    got = msl.dense_gemm_rows_direct(xh, code, K, ic, oc, R)
+    assert got.shape == (m, oc)
+    assert np.array_equal(np.array(got), np.array(want))
+
+
+@needs_metal
 def test_row_blocked_gemm_does_not_touch_rows_outside_the_batch():
     """The dense GEMM has no padding sink row: the tail group's padding slots
     stage a real row and are dropped by a store guard. If that guard were wrong
@@ -491,6 +522,79 @@ def test_simdgroup_matrix_gemm_is_deterministic_and_close():
             mx.eval(again)
             assert bool((got.view(mx.uint32) == again.view(mx.uint32)).all()), \
                 f"K={K} m={m} not reproducible run to run"
+
+
+@needs_metal
+@pytest.mark.parametrize("K0,K1", [(2, 2), (2, 3), (3, 2)])
+@pytest.mark.parametrize("m,R", [(4, 4), (8, 8), (9, 8)])
+def test_two_projection_gemm_matches_separate_kernels(K0, K1, m, R):
+    """Projection fusion changes dispatch geometry, never row arithmetic."""
+    import mlx.core as mx
+    from escha_mlx import msl
+
+    rng = np.random.default_rng(980 + 10 * K0 + K1 + m)
+    ic, oc0, oc1 = BIG_IC, BIG_OC, 256
+    code0 = mx.array(msl.code_to_u32(rng.integers(
+        -32768, 32768, size=(ic // 16, oc0 // 16, 16 * K0), dtype=np.int16)))
+    code1 = mx.array(msl.code_to_u32(rng.integers(
+        -32768, 32768, size=(ic // 16, oc1 // 16, 16 * K1), dtype=np.int16)))
+    x0 = mx.array((rng.standard_normal((m, ic)) * 0.3).astype(np.float16))
+    x1 = mx.array((rng.standard_normal((m, ic)) * 0.3).astype(np.float16))
+    kernel = msl.dense_gemm_rows_direct if R <= 4 else msl.dense_gemm_rows
+    ref0 = kernel(x0, code0, K0, ic, oc0, R)
+    ref1 = kernel(x1, code1, K1, ic, oc1, R)
+    got0, got1 = msl.dense_gemm_pair(
+        x0, x1, code0, code1, K0, K1, ic, oc0, oc1, R
+    )
+    mx.eval(ref0, ref1, got0, got1)
+    assert np.array_equal(np.array(got0), np.array(ref0))
+    assert np.array_equal(np.array(got1), np.array(ref1))
+    rout0 = mx.array(rng.standard_normal(oc0).astype(np.float32))
+    rout1 = mx.array(rng.standard_normal(oc1).astype(np.float32))
+    want0 = msl.dense_scaled_had_out(ref0, rout0, _ref().RS)
+    want1 = msl.dense_scaled_had_out(ref1, rout1, _ref().RS)
+    fused0 = msl.dense_gemm_rows_direct_out(
+        x0, code0, rout0, K0, ic, oc0, R, _ref().RS
+    )
+    pair0, pair1 = msl.dense_gemm_pair_out(
+        x0, x1, code0, code1, rout0, rout1,
+        K0, K1, ic, oc0, oc1, R, _ref().RS,
+    )
+    mx.eval(want0, want1, fused0, pair0, pair1)
+    assert np.array_equal(np.array(fused0), np.array(want0))
+    assert np.array_equal(np.array(pair0), np.array(want0))
+    assert np.array_equal(np.array(pair1), np.array(want1))
+
+
+@needs_metal
+def test_two_projection_hadamards_match_separate_dispatches():
+    import mlx.core as mx
+    from escha_mlx import msl, ref
+
+    rng = np.random.default_rng(1021)
+    m, ic, oc0, oc1 = 8, 256, 384, 256
+    rows = mx.array(rng.standard_normal((m, ic)).astype(np.float16))
+    rin0 = mx.array(rng.standard_normal(ic).astype(np.float32))
+    rin1 = mx.array(rng.standard_normal(ic).astype(np.float32))
+    ref0 = msl.dense_scaled_had(rows, rin0, ref.RS)
+    ref1 = msl.dense_scaled_had(rows, rin1, ref.RS)
+    got0, got1 = msl.dense_scaled_had_pair(rows, rin0, rin1, ref.RS)
+    mx.eval(ref0, ref1, got0, got1)
+    assert np.array_equal(np.array(got0), np.array(ref0))
+    assert np.array_equal(np.array(got1), np.array(ref1))
+
+    mid0 = mx.array(rng.standard_normal((m, oc0)).astype(np.float32))
+    mid1 = mx.array(rng.standard_normal((m, oc1)).astype(np.float32))
+    rout0 = mx.array(rng.standard_normal(oc0).astype(np.float32))
+    rout1 = mx.array(rng.standard_normal(oc1).astype(np.float32))
+    ref0 = msl.dense_scaled_had_out(mid0, rout0, ref.RS)
+    ref1 = msl.dense_scaled_had_out(mid1, rout1, ref.RS)
+    got0, got1 = msl.dense_scaled_had_out_pair(
+        mid0, mid1, rout0, rout1, ref.RS
+    )
+    mx.eval(ref0, ref1, got0, got1)
+    assert np.array_equal(np.array(got0), np.array(ref0))
+    assert np.array_equal(np.array(got1), np.array(ref1))
 
 
 @needs_mlx

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -19,6 +19,7 @@ EXPECTED_LAYERS = {
     },
     envs.EnvLayer.KERNEL: {
         "ESCHA_MLX_DENSE",
+        "ESCHA_MLX_Q8_HEAD",
         "ESCHA_MLX_MOE",
         "ESCHA_MLX_FUSED_HAD",
         "ESCHA_MLX_LUT",
@@ -69,6 +70,7 @@ def test_defaults_and_call_site_default(monkeypatch):
     assert envs.ESCHA_MLX_Q8_GROUP.get() == quant.DEFAULT_GROUP
     assert envs.ESCHA_MLX_BIAS.get() is False
     assert envs.ESCHA_MLX_DENSE.get() == "q8"
+    assert envs.ESCHA_MLX_Q8_HEAD.get() is True
     assert envs.ESCHA_MLX_MOE.get() is None
     assert envs.ESCHA_MLX_MOE.get(default="ops") == "ops"
     assert envs.ESCHA_MLX_SPLITK.get() == 1

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -150,7 +150,7 @@ def test_synthetic_checkpoint_end_to_end(tmp_path):
     import mlx.core as mx
     from escha_mlx.loader import LastPositionHead, load_model
     from escha_mlx.models.qwen3_5_moe import EschaSparseMoeBlock
-    from escha_mlx.quant import EschaQ8Embedding, EschaQ8Linear
+    from escha_mlx.quant import EschaQ8Embedding, EschaQ8Head, EschaQ8Linear
 
     _write_tiny_checkpoint(tmp_path, np.random.default_rng(0))
     model = load_model(tmp_path)
@@ -160,7 +160,7 @@ def test_synthetic_checkpoint_end_to_end(tmp_path):
     assert isinstance(model.language_model.model.embed_tokens, EschaQ8Embedding)
     assert isinstance(layers[1].self_attn.q_proj, EschaQ8Linear)
     head = model.language_model.lm_head
-    assert isinstance(head, LastPositionHead) and isinstance(head.inner, EschaQ8Linear)
+    assert isinstance(head, LastPositionHead) and isinstance(head.inner, EschaQ8Head)
 
     def forward():
         cache = model.make_cache()
@@ -304,7 +304,7 @@ def test_dense_synthetic_checkpoint_end_to_end(tmp_path, monkeypatch):
     import mlx.core as mx
     from escha_mlx.dense import EschaLinear
     from escha_mlx.loader import LastPositionHead, load_model
-    from escha_mlx.quant import EschaQ8Embedding, EschaQ8Linear
+    from escha_mlx.quant import EschaQ8Embedding, EschaQ8Head
 
     monkeypatch.setenv("ESCHA_MLX_LINEAR", "ops")   # portable path: CI has no Metal
     monkeypatch.setenv("ESCHA_MLX_BIAS", "1")       # exercise the correction path
@@ -340,7 +340,7 @@ def test_dense_synthetic_checkpoint_end_to_end(tmp_path, monkeypatch):
 
     assert isinstance(model.language_model.model.embed_tokens, EschaQ8Embedding)
     head = model.language_model.lm_head
-    assert isinstance(head, LastPositionHead) and isinstance(head.inner, EschaQ8Linear)
+    assert isinstance(head, LastPositionHead) and isinstance(head.inner, EschaQ8Head)
 
     def forward():
         cache = model.make_cache()

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -1,0 +1,936 @@
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from .conftest import needs_metal, needs_mlx
+
+
+TINY_MTP_CONFIG = {
+    "model_type": "qwen3_5",
+    "text_config": {
+        "model_type": "qwen3_5_text",
+        "hidden_size": 128,
+        "intermediate_size": 256,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "vocab_size": 256,
+        "linear_num_value_heads": 4,
+        "linear_num_key_heads": 2,
+        "linear_key_head_dim": 32,
+        "linear_value_head_dim": 32,
+        "linear_conv_kernel_dim": 4,
+        "full_attention_interval": 2,
+        "mtp_num_hidden_layers": 1,
+        "mtp_use_dedicated_embeddings": False,
+        "tie_word_embeddings": False,
+    },
+}
+
+
+def _target():
+    from mlx_lm.models import qwen3_5
+
+    return qwen3_5.Model(qwen3_5.ModelArgs.from_dict(TINY_MTP_CONFIG))
+
+
+def _write_mtp(path, target):
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+    from safetensors.numpy import save_file
+
+    from escha_mlx.mtp import MTPHead, _NORM_WEIGHTS
+
+    source = MTPHead(TINY_MTP_CONFIG, target)
+    weights = {}
+    for name, value in tree_flatten(source.parameters()):
+        value = np.array(value).astype(np.float16)
+        if name in _NORM_WEIGHTS:
+            value = (value.astype(np.float32) - 1.0).astype(np.float16)
+        weights["mtp." + name] = value
+    mtp_dir = path / "mtp"
+    mtp_dir.mkdir()
+    (mtp_dir / "config.json").write_text(json.dumps(TINY_MTP_CONFIG))
+    save_file(weights, str(mtp_dir / "model.safetensors"))
+    mx.clear_cache()
+    return weights
+
+
+@needs_mlx
+def test_mtp_loads_exact_15_tensors_and_shares_vocab(tmp_path):
+    from mlx.utils import tree_flatten
+
+    from escha_mlx.mtp import _NORM_WEIGHTS, load_mtp
+
+    target = _target()
+    weights = _write_mtp(tmp_path, target)
+    mtp_head = load_mtp(tmp_path, target)
+
+    params = dict(tree_flatten(mtp_head.parameters()))
+    assert len(params) == len(weights) == 15
+    assert mtp_head._embed_tokens is target.language_model.model.embed_tokens
+    assert mtp_head._lm_head is target.language_model.lm_head
+    for name, value in params.items():
+        expected = weights["mtp." + name]
+        if name in _NORM_WEIGHTS:
+            expected = (expected.astype(np.float32) + 1.0).astype(np.float16)
+        assert np.array_equal(np.array(value), expected), name
+
+
+@needs_mlx
+def test_mtp_forward_advances_single_attention_cache(tmp_path):
+    import mlx.core as mx
+
+    from escha_mlx.mtp import load_mtp
+
+    target = _target()
+    _write_mtp(tmp_path, target)
+    mtp_head = load_mtp(tmp_path, target)
+    cache = mtp_head.make_cache()
+    tokens = mx.array([[1, 2, 3]], dtype=mx.uint32)
+    hidden = mx.zeros((1, 3, 128), dtype=mx.float16)
+    logits = mtp_head(tokens, hidden, cache)
+    mx.eval(logits, [c.state for c in cache])
+
+    assert logits.shape == (1, 3, 256)
+    assert cache[0].offset == 3
+    assert np.isfinite(np.array(logits)).all()
+
+
+@needs_mlx
+def test_mtp_generation_matches_target_greedy(tmp_path):
+    import mlx.core as mx
+
+    from escha_mlx.mtp import load_mtp, mtp_generate_step
+
+    mx.random.seed(7)
+    target = _target()
+    target.eval()
+    _write_mtp(tmp_path, target)
+    mtp_head = load_mtp(tmp_path, target)
+    prompt = mx.array([1, 7, 9, 4], dtype=mx.uint32)
+
+    # Reference uses one full-prompt forward followed by one-token decode, the
+    # same target-cache boundary used by MTP bootstrap.
+    cache = target.make_cache()
+    hidden = target.language_model.model(prompt[None], cache=cache)
+    logits = target.language_model.lm_head(hidden[:, -1:])
+    token = mx.argmax(logits[:, -1], axis=-1).astype(mx.uint32)
+    reference = [int(token.item())]
+    for _ in range(5):
+        hidden = target.language_model.model(token[None], cache=cache)
+        logits = target.language_model.lm_head(hidden)
+        token = mx.argmax(logits[:, -1], axis=-1).astype(mx.uint32)
+        mx.eval(token, [c.state for c in cache])
+        reference.append(int(token.item()))
+
+    generated = list(
+        mtp_generate_step(
+            prompt,
+            target,
+            mtp_head=mtp_head,
+            max_tokens=6,
+            prefill_step_size=16,
+        )
+    )
+    assert [token for token, _, _ in generated] == reference
+    assert len(generated) == 6
+
+
+@needs_mlx
+def test_mtp_single_token_prompt_matches_target_greedy(tmp_path):
+    """An empty shifted prefill must leave the MTP KV cache unallocated safely."""
+    import mlx.core as mx
+    from mlx_lm.generate import generate_step
+
+    from escha_mlx.mtp import load_mtp, mtp_generate_step
+
+    mx.random.seed(9)
+    target = _target()
+    target.eval()
+    _write_mtp(tmp_path, target)
+    head = load_mtp(tmp_path, target)
+    prompt = mx.array([7], dtype=mx.uint32)
+
+    reference = [
+        int(token)
+        for token, _ in generate_step(prompt, target, max_tokens=4)
+    ]
+    generated = [
+        token
+        for token, _, _ in mtp_generate_step(
+            prompt, target, mtp_head=head, max_tokens=4
+        )
+    ]
+    assert generated == reference
+
+
+@needs_mlx
+def test_mtp_continuous_batch_matches_target_greedy(tmp_path):
+    """Batched MTP keeps every request on the target model's token path."""
+    import mlx.core as mx
+    from mlx_lm.generate import BatchGenerator
+
+    from escha_mlx.mtp import load_mtp
+    from escha_mlx.mtp_batch import MTPBatchGenerator
+
+    mx.random.seed(13)
+    target = _target()
+    target.eval()
+    _write_mtp(tmp_path, target)
+    target.mtp = load_mtp(tmp_path, target)
+    prompts = [[1, 7, 9, 4], [3], [8, 5, 6]]
+    limits = [7, 5, 6]
+
+    def collect(generator):
+        uids = generator.insert(prompts, max_tokens=limits)
+        output = {uid: [] for uid in uids}
+        while responses := generator.next_generated():
+            for response in responses:
+                output[response.uid].append(response.token)
+        generator.close()
+        return [output[uid] for uid in uids]
+
+    baseline = collect(
+        BatchGenerator(
+            target,
+            completion_batch_size=3,
+            prefill_batch_size=3,
+            prefill_step_size=16,
+        )
+    )
+    speculative = collect(
+        MTPBatchGenerator(
+            target,
+            completion_batch_size=3,
+            prefill_batch_size=3,
+            prefill_step_size=16,
+        )
+    )
+    assert speculative == baseline
+    assert list(map(len, speculative)) == limits
+
+
+@needs_mlx
+def test_mtp_batch_rejects_rotating_cache_before_generation(tmp_path):
+    from escha_mlx.mtp import load_mtp
+    from escha_mlx.mtp_batch import MTPBatchGenerator
+
+    target = _target()
+    target.eval()
+    _write_mtp(tmp_path, target)
+    target.mtp = load_mtp(tmp_path, target)
+
+    with pytest.raises(ValueError, match="does not support max_kv_size"):
+        MTPBatchGenerator(target, max_kv_size=4)
+
+
+@needs_mlx
+def test_mtp_cache_accounting_includes_online_prompt_cache(tmp_path):
+    from mlx_lm.generate import BatchGenerator
+
+    from escha_mlx.mtp import load_mtp
+    from escha_mlx.mtp_batch import MTPBatchGenerator
+
+    target = _target()
+    target.eval()
+    _write_mtp(tmp_path, target)
+    target.mtp = load_mtp(tmp_path, target)
+    generator = MTPBatchGenerator(target, prefill_step_size=2)
+    generator.insert([[1, 2, 3, 4, 5, 6, 7, 8]], max_tokens=[3])
+    generator.next()
+
+    target_bytes = BatchGenerator.prompt_cache_nbytes.fget(generator)
+    prompt_mtp_bytes = sum(item.nbytes for item in generator._prompt_batch.mtp_cache)
+    generation_mtp_bytes = sum(
+        item.nbytes for item in generator._generation_batch.mtp_cache
+    )
+    assert prompt_mtp_bytes > 0
+    assert generator.prompt_cache_nbytes == (
+        target_bytes + prompt_mtp_bytes + generation_mtp_bytes
+    )
+    generator.close()
+
+
+@needs_mlx
+def test_fresh_batch_prefill_does_not_replay_target_body(tmp_path, monkeypatch):
+    import mlx.core as mx
+
+    from escha_mlx.mtp import load_mtp
+    from escha_mlx.mtp_batch import MTPBatchGenerator, MTPGenerationBatch
+
+    mx.random.seed(15)
+    target = _target()
+    target.eval()
+    _write_mtp(tmp_path, target)
+    target.mtp = load_mtp(tmp_path, target)
+
+    def reject_replay(self, last_prompt_tokens):
+        raise AssertionError("fresh prompt unexpectedly replayed the target body")
+
+    monkeypatch.setattr(MTPGenerationBatch, "_prefill_mtp_head", reject_replay)
+    generator = MTPBatchGenerator(
+        target, completion_batch_size=2, prefill_batch_size=2,
+        prefill_step_size=2,
+    )
+    generator.insert([[1, 7, 9, 4], [3]], max_tokens=[3, 3])
+    assert generator.next_generated()
+    generator.close()
+
+
+@needs_mlx
+def test_cached_batch_prompt_uses_replay_fallback(tmp_path, monkeypatch):
+    import mlx.core as mx
+    from mlx_lm.generate import BatchGenerator
+
+    from escha_mlx.mtp import load_mtp
+    from escha_mlx.mtp_batch import MTPBatchGenerator, MTPGenerationBatch
+
+    mx.random.seed(16)
+    target = _target()
+    target.eval()
+    _write_mtp(tmp_path, target)
+    target.mtp = load_mtp(tmp_path, target)
+    prompt, prefix, suffix = [1, 7, 9, 4], [1, 7], [9, 4]
+
+    reference = BatchGenerator(target)
+    (reference_uid,) = reference.insert([prompt], max_tokens=[5])
+    expected = []
+    while responses := reference.next_generated():
+        expected.extend(r.token for r in responses if r.uid == reference_uid)
+    reference.close()
+
+    cache = target.make_cache()
+    target.language_model.model(mx.array([prefix]), cache=cache)
+    mx.eval([item.state for item in cache])
+    replay_calls = 0
+    original = MTPGenerationBatch._prefill_mtp_head
+
+    def count_replay(self, last_prompt_tokens):
+        nonlocal replay_calls
+        replay_calls += 1
+        return original(self, last_prompt_tokens)
+
+    monkeypatch.setattr(MTPGenerationBatch, "_prefill_mtp_head", count_replay)
+    generator = MTPBatchGenerator(target)
+    (uid,) = generator.insert(
+        [suffix], caches=[cache], all_tokens=[prefix], max_tokens=[5]
+    )
+    actual = []
+    while responses := generator.next_generated():
+        actual.extend(r.token for r in responses if r.uid == uid)
+    generator.close()
+
+    assert replay_calls == 1
+    assert actual == expected
+
+
+@needs_mlx
+def test_mtp_continuous_batch_accepts_late_request(tmp_path):
+    """A request can join an already-decoding MTP batch."""
+    import mlx.core as mx
+    from mlx_lm.generate import BatchGenerator
+
+    from escha_mlx.mtp import load_mtp
+    from escha_mlx.mtp_batch import MTPBatchGenerator
+
+    mx.random.seed(17)
+    target = _target()
+    target.eval()
+    _write_mtp(tmp_path, target)
+    target.mtp = load_mtp(tmp_path, target)
+    prompts = [[1, 4, 7], [2, 9], [5, 3, 8, 6]]
+    limits = [6, 6, 6]
+
+    reference = BatchGenerator(
+        target, completion_batch_size=3, prefill_batch_size=3, prefill_step_size=16
+    )
+    reference_ids = reference.insert(prompts, max_tokens=limits)
+    expected = {uid: [] for uid in reference_ids}
+    while responses := reference.next_generated():
+        for response in responses:
+            expected[response.uid].append(response.token)
+    reference.close()
+
+    generator = MTPBatchGenerator(
+        target,
+        completion_batch_size=3,
+        prefill_batch_size=2,
+        prefill_step_size=16,
+    )
+    first_ids = generator.insert(prompts[:2], max_tokens=limits[:2])
+    got = {uid: [] for uid in first_ids}
+    for response in generator.next_generated():
+        got[response.uid].append(response.token)
+    (late_id,) = generator.insert([prompts[2]], max_tokens=[limits[2]])
+    got[late_id] = []
+    while responses := generator.next_generated():
+        for response in responses:
+            got[response.uid].append(response.token)
+    generator.close()
+
+    assert [got[uid] for uid in [*first_ids, late_id]] == [
+        expected[uid] for uid in reference_ids
+    ]
+
+
+@needs_mlx
+def test_mtp_batch_releases_previous_trace_before_next_round(monkeypatch):
+    """Only one large GDN tree trace may remain live during verification."""
+    import mlx.core as mx
+
+    from escha_mlx.mtp_batch import MTPGenerationBatch
+
+    batch = MTPGenerationBatch.__new__(MTPGenerationBatch)
+    batch._mtp_bootstrapped = True
+    batch._last_target_trace = [object()]
+    batch._last_target_chains = [[0, 1]]
+    batch._next_tokens = mx.array([3], dtype=mx.uint32)
+    batch._next_logprobs = [mx.array([0.0])]
+    batch.max_tokens = [4]
+    batch._num_tokens = [0]
+
+    def tree_step(self, current):
+        assert self._last_target_trace == []
+        assert self._last_target_chains == []
+        return [[int(current[0].item())]], [[self._current_logprobs[0]]]
+
+    monkeypatch.setattr(MTPGenerationBatch, "_tree_step", tree_step)
+    tokens, _ = batch._step()
+    assert tokens == [[3]]
+
+
+@needs_mlx
+def test_mtp_batch_early_stop_extracts_exact_cache_prefix(tmp_path):
+    """EOS inside an accepted burst must not save later speculative states."""
+    import mlx.core as mx
+
+    from escha_mlx.mtp import load_mtp
+    from escha_mlx.mtp_batch import MTPBatchGenerator
+
+    mx.random.seed(19)
+    target = _target()
+    target.eval()
+    _write_mtp(tmp_path, target)
+    target.mtp = load_mtp(tmp_path, target)
+    # A zero target head makes the tree contain token 0 and lets the stop
+    # machine cut an accepted burst back to its first position.
+    target.language_model.lm_head.weight = mx.zeros_like(
+        target.language_model.lm_head.weight
+    )
+    prompts = [[1, 7, 9, 4], [3, 2]]
+    generator = MTPBatchGenerator(
+        target,
+        stop_tokens=[[0]],
+        completion_batch_size=2,
+        prefill_batch_size=2,
+        prefill_step_size=16,
+    )
+    uids = generator.insert(prompts, max_tokens=[8, 8])
+    responses = generator.next_generated()
+    generator.close()
+
+    assert len(responses) == 2
+    by_uid = {response.uid: response for response in responses}
+    for uid, prompt in zip(uids, prompts):
+        response = by_uid[uid]
+        assert response.token == 0
+        assert response.finish_reason == "stop"
+        assert response.all_tokens == prompt + [0]
+        attention_caches = [c for c in response.prompt_cache if c.is_trimmable()]
+        assert attention_caches
+        assert all(c.offset == len(prompt) + 1 for c in attention_caches)
+
+
+def test_server_mtp_args_are_consumed():
+    from escha_mlx.server import _consume_mtp_args
+
+    argv, enabled = _consume_mtp_args(
+        ["server", "--model", "m", "--mtp", "--port", "9"]
+    )
+    assert argv == ["server", "--model", "m", "--port", "9"]
+    assert enabled is True
+
+    argv, enabled = _consume_mtp_args(["server", "--port", "9"])
+    assert argv == ["server", "--port", "9"]
+    assert enabled is False
+
+
+def test_server_mtp_prompt_cache_has_default_and_explicit_byte_caps():
+    from escha_mlx.server import (
+        _MTP_DEFAULT_PROMPT_CACHE_BYTES,
+        _append_default_option,
+        _install_mtp_prompt_cache_limit,
+    )
+
+    class FakeLRU:
+        def __init__(self, *, max_size, max_bytes):
+            self.max_size = max_size
+            self.max_bytes = max_bytes
+
+    class FakeServer:
+        LRUPromptCache = FakeLRU
+
+        @staticmethod
+        def _parse_size(value):
+            units = {"MB": 1_000_000, "GB": 1_000_000_000}
+            for suffix, scale in units.items():
+                if value.endswith(suffix):
+                    return int(float(value[: -len(suffix)]) * scale)
+            return int(value)
+
+    defaults = ["server", "--model", "m", "--decode-concurrency=4"]
+    assert not _append_default_option(defaults, "--decode-concurrency", "2")
+    assert _append_default_option(defaults, "--prompt-concurrency", "2")
+    assert defaults[-2:] == ["--prompt-concurrency", "2"]
+
+    argv = ["server", "--model", "m"]
+    budget = _install_mtp_prompt_cache_limit(FakeServer, argv)
+    cache = FakeServer.LRUPromptCache(10)
+    assert budget == _MTP_DEFAULT_PROMPT_CACHE_BYTES
+    assert argv[-2:] == ["--prompt-cache-bytes", str(budget)]
+    assert cache.max_size == 10
+    assert cache.max_bytes == budget
+
+    class ExplicitServer:
+        LRUPromptCache = FakeLRU
+        _parse_size = staticmethod(FakeServer._parse_size)
+
+    argv = ["server", "--prompt-cache-bytes=1GB"]
+    budget = _install_mtp_prompt_cache_limit(ExplicitServer, argv)
+    cache = ExplicitServer.LRUPromptCache(3)
+    assert budget == 1_000_000_000
+    assert argv == ["server", "--prompt-cache-bytes=1GB"]
+    assert cache.max_bytes == budget
+
+
+@needs_mlx
+def test_tree_logits_processors_receive_only_ancestor_tokens():
+    import mlx.core as mx
+
+    from escha_mlx.mtp_batch import MTPGenerationBatch
+
+    contexts = []
+
+    def processor(context, logits):
+        contexts.append(context.tolist())
+        return logits
+
+    batch = MTPGenerationBatch.__new__(MTPGenerationBatch)
+    batch.logits_processors = [[processor]]
+    batch.samplers = [None]
+    batch.fallback_sampler = lambda logprobs: mx.argmax(logprobs, axis=-1)
+    batch._token_context = [
+        type("Context", (), {"tokens": mx.array([1, 2], dtype=mx.uint32)})()
+    ]
+    prefixes = mx.array([[10, 20, 30, 40]], dtype=mx.uint32)
+    parents = [[-1, 0, 0, 1]]
+
+    batch._sample(mx.zeros((1, 4, 8)), prefixes, parents)
+
+    assert contexts == [
+        [1, 2, 10],
+        [1, 2, 10, 20],
+        [1, 2, 10, 30],
+        [1, 2, 10, 20, 40],
+    ]
+
+
+@needs_mlx
+def test_tree_commit_matches_independent_ar_path():
+    import mlx.core as mx
+
+    from escha_mlx.mtp import (
+        _commit_tree_cache,
+        _mark_cache,
+        _target_tree_forward,
+    )
+
+    mx.random.seed(11)
+    target = _target()
+    target.eval()
+    prompt = mx.array([[1, 2, 3]], dtype=mx.uint32)
+    candidates = mx.array([[4, 5, 6, 7]], dtype=mx.uint32)
+    traced_cache = target.make_cache()
+    reference_cache = target.make_cache()
+
+    target.language_model.model(prompt, cache=traced_cache)
+    target.language_model.model(prompt, cache=reference_cache)
+    mark = _mark_cache(traced_cache)
+    parents = mx.array([[-1, 0, 0, 1]], dtype=mx.int32)
+    depths = mx.array([[0, 1, 1, 2]], dtype=mx.int32)
+    traced_hidden, _, trace = _target_tree_forward(
+        target, candidates, parents, depths, traced_cache
+    )
+    mx.eval(traced_hidden, [entry[1:] for entry in trace],
+            [c.state for c in traced_cache])
+
+    # Commit the accepted branch 4 -> 5 -> 7, discarding sibling token 6.
+    chain = [0, 1, 3]
+    _commit_tree_cache(traced_cache, mark, chain, trace)
+    reference_hidden = target.language_model.model(
+        mx.take(candidates[0], mx.array(chain, dtype=mx.int32))[None],
+        cache=reference_cache,
+    )
+    next_token = mx.array([[8]], dtype=mx.uint32)
+    traced_next = target.language_model.model(next_token, cache=traced_cache)
+    reference_next = target.language_model.model(next_token, cache=reference_cache)
+    mx.eval(
+        reference_hidden,
+        traced_next,
+        reference_next,
+        [c.state for c in traced_cache],
+        [c.state for c in reference_cache],
+    )
+
+    assert np.allclose(
+        np.array(traced_hidden[:, 3]), np.array(reference_hidden[:, -1]),
+        rtol=2e-3, atol=5e-3,
+    )
+    assert np.allclose(
+        np.array(traced_next), np.array(reference_next), rtol=2e-3, atol=5e-3
+    )
+
+
+@needs_mlx
+def test_m4_tree_has_three_topological_draft_nodes(tmp_path):
+    import mlx.core as mx
+    from mlx_lm.models.cache import BatchKVCache
+
+    from escha_mlx.mtp import _propose_tree, load_mtp
+
+    mx.random.seed(29)
+    target = _target()
+    target.eval()
+    _write_mtp(tmp_path, target)
+    head = load_mtp(tmp_path, target)
+    cache = [BatchKVCache([0, 0])]
+    hidden = mx.zeros((2, 1, 128), dtype=mx.float16)
+    seed_hidden = head.forward_hidden(
+        mx.array([[7], [11]], dtype=mx.uint32), hidden, cache
+    )
+    seed_logits = head.logits(seed_hidden)[:, -1]
+    tree = _propose_tree(head, seed_hidden, seed_logits, cache)
+    mx.eval(tree.tokens, tree.parents, tree.depths)
+
+    assert tree.tokens.shape == (2, 3)
+    assert tree.parents.shape == tree.depths.shape == (2, 4)
+    assert cache[0].keys.shape[0] == 2
+    assert cache[0].offset.tolist() == [1, 1]
+    for parents, depths in zip(tree.parents.tolist(), tree.depths.tolist()):
+        assert parents[0] == -1 and depths[0] == 0
+        assert all(0 <= parents[node] < node for node in range(1, 4))
+        assert all(depths[node] == depths[parents[node]] + 1 for node in range(1, 4))
+        assert max(depths) <= 3
+
+
+@needs_mlx
+def test_gpu_tree_masks_match_ancestry_and_prefix_padding():
+    import mlx.core as mx
+
+    from escha_mlx.mtp import _incremental_tree_mask, _tree_mask
+
+    parents = mx.array(
+        [
+            [-1, 0, 0, 1, 1, 2, 3, 3],
+            [-1, 0, 0, 0, 2, 2, 4, 5],
+        ],
+        dtype=mx.int32,
+    )
+    padding = mx.array([1, 3], dtype=mx.int32)
+
+    def expected(start):
+        rows = []
+        for tree, left in zip(parents.tolist(), padding.tolist()):
+            batch = []
+            for node in range(start, len(tree)):
+                visible = [position >= left for position in range(4)]
+                ancestry = [False] * len(tree)
+                current = node
+                while current >= 0:
+                    ancestry[current] = True
+                    current = tree[current]
+                batch.append(visible + ancestry)
+            rows.append(batch)
+        return np.array(rows, dtype=np.bool_)[:, None]
+
+    full = _tree_mask(parents, 4, padding)
+    incremental = _incremental_tree_mask(parents, 5, 4, padding)
+    mx.eval(full, incremental)
+    assert np.array_equal(np.array(full), expected(0))
+    assert np.array_equal(np.array(incremental), expected(5))
+
+
+@needs_mlx
+def test_target_tree_verifier_matches_independent_ar_paths():
+    """Every verified node represents the same target context as its AR path."""
+    import mlx.core as mx
+
+    from escha_mlx.mtp import _target_tree_forward
+
+    mx.random.seed(303)
+    target = _target()
+    target.eval()
+    prompt = mx.array([[1, 2, 3]], dtype=mx.uint32)
+    verify_ids = mx.array([[4, 5, 6, 7]], dtype=mx.uint32)
+    parents = mx.array([[-1, 0, 0, 1]], dtype=mx.int32)
+    depths = mx.array([[0, 1, 1, 2]], dtype=mx.int32)
+    tree_cache = target.make_cache()
+    target.language_model.model(prompt, cache=tree_cache)
+    tree_hidden, tree_logits, _ = _target_tree_forward(
+        target, verify_ids, parents, depths, tree_cache
+    )
+    mx.eval(tree_hidden, tree_logits)
+
+    for node in range(verify_ids.shape[1]):
+        path = []
+        current = node
+        while current >= 0:
+            path.append(current)
+            current = int(parents[0, current].item())
+        path.reverse()
+        cache = target.make_cache()
+        target.language_model.model(prompt, cache=cache)
+        hidden = target.language_model.model(
+            mx.take(verify_ids[0], mx.array(path, dtype=mx.int32))[None],
+            cache=cache,
+        )
+        logits = target.language_model.lm_head(hidden)
+        mx.eval(hidden, logits)
+
+        assert np.allclose(
+            np.array(tree_hidden[0, node]),
+            np.array(hidden[0, -1]),
+            rtol=2e-3,
+            atol=5e-3,
+        )
+        assert np.allclose(
+            np.array(tree_logits[0, node]),
+            np.array(logits[0, -1]),
+            rtol=2e-3,
+            atol=5e-3,
+        )
+        assert int(mx.argmax(tree_logits[0, node]).item()) == int(
+            mx.argmax(logits[0, -1]).item()
+        )
+
+
+@needs_mlx
+def test_tree_gdn_uses_each_nodes_parent_state():
+    import mlx.core as mx
+
+    from escha_mlx import gdn_cache
+
+    mx.random.seed(31)
+    B, T, Hk, Hv, Dk, Dv = 2, 8, 2, 4, 32, 8
+    q = mx.random.normal((B, T, Hk, Dk)).astype(mx.float16)
+    k = mx.random.normal((B, T, Hk, Dk)).astype(mx.float16)
+    v = mx.random.normal((B, T, Hv, Dv)).astype(mx.float16)
+    a = mx.random.normal((B, T, Hv)).astype(mx.float16)
+    b = mx.random.normal((B, T, Hv)).astype(mx.float16)
+    A_log = mx.random.normal((Hv,)).astype(mx.float32)
+    dt_bias = mx.random.normal((Hv,)).astype(mx.float32)
+    state = mx.random.normal((B, Hv, Dv, Dk)).astype(mx.float32)
+    parent_rows = [[-1, 0, 0, 0, 1, 1, 2, 4], [-1, 0, 0, 1, 1, 2, 3, 5]]
+    parents = mx.array(parent_rows, dtype=mx.int32)
+    tree_out, tree_states = gdn_cache.gated_delta_tree_trace_update(
+        q, k, v, a, b, A_log, dt_bias, state, parents
+    )
+    mx.eval(tree_out, tree_states)
+
+    for batch, parent_row in enumerate(parent_rows):
+        for node in range(T):
+            path, current = [], node
+            while current >= 0:
+                path.append(current)
+                current = parent_row[current]
+            path.reverse()
+            indices = mx.array(path, dtype=mx.int32)
+            out, states = gdn_cache.gated_delta_trace_update(
+                mx.take(q[batch : batch + 1], indices, axis=1),
+                mx.take(k[batch : batch + 1], indices, axis=1),
+                mx.take(v[batch : batch + 1], indices, axis=1),
+                mx.take(a[batch : batch + 1], indices, axis=1),
+                mx.take(b[batch : batch + 1], indices, axis=1),
+                A_log,
+                dt_bias,
+                state[batch : batch + 1],
+            )
+            mx.eval(out, states)
+            assert np.allclose(
+                np.array(tree_out[batch, node]), np.array(out[0, -1]),
+                rtol=2e-3, atol=2e-3,
+            )
+            assert np.allclose(
+                np.array(tree_states[batch, node]), np.array(states[0, -1]),
+                rtol=2e-5, atol=2e-5,
+            )
+
+
+@needs_metal
+def test_tree_conv_window_kernel_matches_topological_reference():
+    import mlx.core as mx
+
+    from escha_mlx import gdn_cache
+
+    rng = np.random.default_rng(47)
+    B, T, C, n_keep = 2, 8, 384, 3
+    qkv = mx.array(rng.standard_normal((B, T, C)).astype(np.float16))
+    state = mx.array(rng.standard_normal((B, n_keep, C)).astype(np.float16))
+    parents = mx.array(
+        [
+            [-1, 0, 0, 1, 1, 2, 3, 6],
+            [-1, 0, 1, 0, 3, 2, 5, 4],
+        ],
+        dtype=mx.int32,
+    )
+
+    states, windows = [], []
+    for t in range(T):
+        choices = mx.stack([state, *states], axis=1)
+        index = (parents[:, t] + 1).reshape(B, 1, 1, 1)
+        parent = mx.take_along_axis(choices, index, axis=1)[:, 0]
+        window = mx.concatenate([parent, qkv[:, t : t + 1]], axis=1)
+        windows.append(window)
+        states.append(mx.contiguous(window[:, 1:]))
+    expected_trace = mx.stack(states, axis=1)
+    expected_windows = mx.stack(windows, axis=1).reshape(B * T, n_keep + 1, C)
+
+    trace, actual_windows = gdn_cache.tree_conv_windows(qkv, state, parents)
+    mx.eval(expected_trace, expected_windows, trace, actual_windows)
+
+    assert np.array_equal(np.array(trace), np.array(expected_trace))
+    assert np.array_equal(np.array(actual_windows), np.array(expected_windows))
+
+
+@needs_metal
+@pytest.mark.parametrize("shape", [(1, 5003), (2, 3, 5003)])
+def test_mtp_metal_topk_log_probs_matches_mlx(shape):
+    import mlx.core as mx
+
+    from escha_mlx.mtp_topk import metal_topk_log_probs
+
+    rng = np.random.default_rng(53)
+    logits = mx.array(rng.standard_normal(shape).astype(np.float16))
+    actual = [metal_topk_log_probs(logits) for _ in range(8)]
+    assert all(result is not None for result in actual)
+
+    log_probs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+    expected_indices = mx.argpartition(-log_probs, kth=2, axis=-1)[..., :3]
+    expected = np.sort(np.array(expected_indices), axis=-1)
+    reference_scores = reference_indices = None
+    for scores, indices in actual:
+        expected_scores = mx.take_along_axis(log_probs, indices, axis=-1)
+        mx.eval(scores, indices, expected_scores)
+        got_scores = np.array(scores)
+        got_indices = np.array(indices)
+
+        assert scores.shape == indices.shape == (*shape[:-1], 3)
+        assert scores.dtype == mx.float16
+        assert indices.dtype == mx.uint32
+        assert np.array_equal(np.sort(got_indices, axis=-1), expected)
+        assert np.allclose(
+            got_scores, np.array(expected_scores), rtol=0.0, atol=1e-2
+        )
+        if reference_scores is not None:
+            assert np.array_equal(got_scores, reference_scores)
+            assert np.array_equal(got_indices, reference_indices)
+        reference_scores, reference_indices = got_scores, got_indices
+
+
+@needs_mlx
+def test_mtp_metal_topk_log_probs_falls_back_outside_specialization():
+    import mlx.core as mx
+
+    from escha_mlx.mtp_topk import metal_topk_log_probs
+
+    logits = mx.zeros((1, 256), dtype=mx.float16)
+    assert metal_topk_log_probs(logits) is None
+    assert metal_topk_log_probs(mx.zeros((5003,), dtype=mx.float16)) is None
+
+
+@needs_mlx
+def test_batch_cache_commits_each_request_path_independently():
+    import mlx.core as mx
+    from mlx_lm.models.cache import BatchKVCache
+
+    from escha_mlx.mtp_batch import _batch_path_marks, _commit_batch_paths
+
+    prefix, width = 3, 8
+    cache = BatchKVCache([0, 1])
+    base = mx.arange(2 * (prefix + width), dtype=mx.float32).reshape(
+        2, 1, prefix + width, 1
+    )
+    cache.state = (
+        base[:, :, :prefix],
+        1000 + base[:, :, :prefix],
+        mx.array([3, 2]),
+        mx.array([0, 1]),
+    )
+    marks = _batch_path_marks([cache])
+    cache.update_and_fetch(
+        base[:, :, prefix:], 1000 + base[:, :, prefix:]
+    )
+    chains = [[0, 2, 5], [0]]
+    _commit_batch_paths([cache], marks, chains, [])
+    mx.eval(cache.state)
+
+    first, second = cache.extract(0), cache.extract(1)
+    expected_first = mx.concatenate(
+        [base[0:1, :, :prefix], mx.take(base[0:1, :, prefix:], mx.array(chains[0]), axis=2)],
+        axis=2,
+    )
+    expected_second = mx.concatenate(
+        [base[1:2, :, 1:prefix], mx.take(base[1:2, :, prefix:], mx.array(chains[1]), axis=2)],
+        axis=2,
+    )
+    assert np.array_equal(np.array(first.keys), np.array(expected_first))
+    assert np.array_equal(np.array(second.keys), np.array(expected_second))
+    assert first.offset == 6 and second.offset == 3
+    assert cache.offset.tolist() == [6, 3]
+
+
+@needs_mlx
+def test_single_tree_cache_gathers_all_attention_layers_before_one_eval(monkeypatch):
+    import mlx.core as mx
+
+    import escha_mlx.mtp as mtp
+
+    class Cache:
+        def __init__(self, start):
+            self.keys = start + mx.arange(7, dtype=mx.float32).reshape(1, 1, 7, 1)
+            self.values = 100 + self.keys
+            self.offset = 7
+
+        def is_trimmable(self):
+            return True
+
+    caches = [Cache(0), Cache(20)]
+    mark = mtp._CacheMark(offsets=[3, 3])
+    real_eval = mx.eval
+    calls = []
+
+    def counted_eval(*args):
+        calls.append(args)
+        return real_eval(*args)
+
+    monkeypatch.setattr(mtp.mx, "eval", counted_eval)
+    mtp._commit_tree_cache(caches, mark, [0, 2], [])
+    real_eval(*[cache.keys for cache in caches], *[cache.values for cache in caches])
+
+    assert len(calls) == 1
+    assert [cache.offset for cache in caches] == [5, 5]
+    assert caches[0].keys.reshape(-1).tolist()[:5] == [0, 1, 2, 3, 5]
+    assert caches[1].keys.reshape(-1).tolist()[:5] == [20, 21, 22, 23, 25]
+
+
+@needs_mlx
+def test_mtp_rejects_incomplete_directory(tmp_path):
+    from escha_mlx.mtp import load_mtp
+
+    with pytest.raises(FileNotFoundError, match="MTP requested"):
+        load_mtp(tmp_path, _target())

--- a/tests/test_quant_metal.py
+++ b/tests/test_quant_metal.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from .conftest import needs_metal
+
+
+pytestmark = needs_metal
+
+
+@pytest.mark.parametrize("rows", [1, 3, 8])
+def test_q8_head_is_deterministic_close_and_keeps_top1(monkeypatch, rows):
+    import mlx.core as mx
+
+    from escha_mlx import quant
+
+    rng = np.random.default_rng(1200 + rows)
+    n, k = 263, 512
+    w8 = rng.integers(-128, 128, size=(n, k), dtype=np.int8)
+    scale = (rng.random(n) * 0.01 + 1e-3).astype(np.float16)
+    packed, scales, biases = quant.pack_q8(w8, scale, 128)
+    standard = quant.EschaQ8Linear(packed, scales, biases, 128)
+    head = quant.EschaQ8Head(packed, scales, biases, 128)
+    x = mx.array(rng.standard_normal((1, rows, k)).astype(np.float16))
+
+    monkeypatch.setenv("ESCHA_MLX_Q8_HEAD", "1")
+    reference = standard(x)
+    got = head(x)
+    again = head(x)
+    mx.eval(reference, got, again)
+
+    delta = mx.abs(reference.astype(mx.float32) - got.astype(mx.float32))
+    relative = float(delta.max()) / max(float(mx.abs(reference).mean()), 1e-6)
+    assert relative < 5e-3
+    assert bool((got.view(mx.uint16) == again.view(mx.uint16)).all())
+    assert np.array_equal(
+        np.array(mx.argmax(got, axis=-1)),
+        np.array(mx.argmax(reference, axis=-1)),
+    )
+
+
+def test_q8_head_flag_and_large_rows_use_mlx_exactly(monkeypatch):
+    import mlx.core as mx
+
+    from escha_mlx import quant
+
+    rng = np.random.default_rng(1230)
+    n, k = 264, 512
+    w8 = rng.integers(-128, 128, size=(n, k), dtype=np.int8)
+    scale = (rng.random(n) * 0.01 + 1e-3).astype(np.float16)
+    packed, scales, biases = quant.pack_q8(w8, scale, 128)
+    standard = quant.EschaQ8Linear(packed, scales, biases, 128)
+    head = quant.EschaQ8Head(packed, scales, biases, 128)
+
+    for rows, enabled in ((8, False), (9, True)):
+        monkeypatch.setenv("ESCHA_MLX_Q8_HEAD", "1" if enabled else "0")
+        x = mx.array(rng.standard_normal((rows, k)).astype(np.float16))
+        reference, got = standard(x), head(x)
+        mx.eval(reference, got)
+        assert bool((got.view(mx.uint16) == reference.view(mx.uint16)).all())


### PR DESCRIPTION
## What

- Add opt-in Qwen3.8 native MTP decoding; it remains disabled by default.
- Implement fixed `topk=3`, `depth=3`, M=4 tree verification for one-shot and continuous-batch generation.
- Add Metal-specialized projection, GDN tree-state, top-k and small-row Q8-head paths.
- Add correctness tests, performance documentation, and fix a threadgroup race in the MTP top-k reduction.

## Numerics

- [ ] Bit-identical: `pytest tests/ -v` green, kernel gates included (paste the Metal gate summary if you touched a kernel)
- [x] OR deliberate numerics change: behind an env flag, previous behavior recoverable, documented in the tuning table in docs/INSTALL.md, validated end-to-end

## Performance (if claimed)

- Machine: Apple M5 Pro, 16-core GPU, 24 GB, macOS 26.6.2, MLX 0.32.0, mlx-lm 0.31.3.
- Workload: Qwen3.8-27B-Escha-W2, batch 1, greedy, 20-token prompt, 256 output tokens, warmed ABBA run.

| Path | Latency | Throughput | Speedup |
|---|---:|---:|---:|
| MTP off | 66.77 ms/token | 14.98 tok/s | 1.000x |
| Tree M4 | 51.35 ms/token | 19.47 tok/s | **1.300x** |

Mean emission was 2.844 tokens per target round. Both paths produced the same token digest for this measured prompt.

## Checklist

- [x] `pytest tests/ -v` passes locally
- [x] Docs updated where behavior or defaults changed
- [x] Commits signed off (`git commit -s`)
